### PR TITLE
fix: sourcemap generation for story files

### DIFF
--- a/packages/builder-rsbuild/src/loaders/export-order-loader.ts
+++ b/packages/builder-rsbuild/src/loaders/export-order-loader.ts
@@ -50,9 +50,17 @@ export default async function loader(
       )
     }
 
-    const generatedMap = magicString.generateMap({ hires: true })
-
-    return callback(null, magicString.toString(), generatedMap, meta)
+    return callback(
+      null,
+      magicString.toString(),
+      map ??
+        magicString.generateMap({
+          hires: true,
+          includeContent: true,
+          source: this.resourcePath,
+        }),
+      meta,
+    )
   } catch (err) {
     return callback(null, source, map, meta)
   }

--- a/packages/react-rsbuild/src/loaders/react-docgen-loader.ts
+++ b/packages/react-rsbuild/src/loaders/react-docgen-loader.ts
@@ -100,6 +100,7 @@ let matchPath: TsconfigPaths.MatchPath | undefined
 export default async function reactDocgenLoader(
   this: LoaderContext<{ debug: boolean }>,
   source: string,
+  map: any,
 ) {
   const callback = this.async()
   // get options
@@ -149,11 +150,16 @@ export default async function reactDocgenLoader(
       }
     })
 
-    const map = magicString.generateMap({
-      includeContent: true,
-      source: this.resourcePath,
-    })
-    callback(null, magicString.toString(), map)
+    callback(
+      null,
+      magicString.toString(),
+      map ??
+        magicString.generateMap({
+          hires: true,
+          source: this.resourcePath,
+          includeContent: true,
+        }),
+    )
   } catch (error: any) {
     if (error.code === ERROR_CODES.MISSING_DEFINITION) {
       callback(null, source)


### PR DESCRIPTION
Related Counter PR at Storybook: https://github.com/storybookjs/storybook/pull/27171

Currently, the sourcemap generation for story files is broken. If rspack behaves like Webpack, then loaders have to chain sourcemaps. This doesn't happen automatically, as Vite/Rollup does. The issue is that the magic-string [doesn't support](https://github.com/Rich-Harris/magic-string/issues/226) sourcemap chaining currently.

The files I have touched only add content at the end of the file. Therefore, creating source maps is not essential since the line/column mapping will stay the same.

This fix only ensures that the source view with enabled sourcemaps in the browser isn't completely broken for `.stories.ts|js` files. The source map mapping still doesn't refer to the original file, but some compiled file returned by some loader in between. I haven't spent too much time to figure out the issue altogether. Someone else could continue from here. The linked PR in Storybook fixes source maps completely for Vite and Webpack5 builders in Storybook

## Reproduction

1. Activate sourcemaps in your browser's developer console
1. Change the Button.stories.tsx in a freshly generated Storybook to

```tsx
import type { Meta, StoryObj } from "@storybook/react";
import { fn } from "@storybook/test";
import { Button } from "./Button";

// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
const meta = {
  title: "Example/Button",
  component: Button,
  args: {
    onClick: () => {
      throw new Error("Not implemented");
    },
  },
} satisfies Meta<typeof Button>;

export default meta;
type Story = StoryObj<typeof meta>;

// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
export const Primary: Story = {
  args: {
    primary: true,
    label: "Button",
  },
};
```

2. Click on a button and try to visit the file in your browser, which throws the error
3. Before the fix, the browser couldn't open the source view at all
4. At least the source view works, although the mapping still does not refer to the original source, but to some precompiled code in between. It seems, that some rspack loaders still don't generate/chain sourcemaps correctly.