### PR TITLE
fix: vitual module should compat with Windows

### DIFF
--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -30,7 +30,11 @@ export const getVirtualModules = async (options: Options) => {
     workingDir,
   })
 
-  const realPathRelativeToCwd = path.relative(workingDir, cwd)
+  // normalize to POSIX path separator for Windows compatibility
+  const realPathRelativeToCwd = path
+    .relative(workingDir, cwd)
+    .split(path.sep)
+    .join(path.posix.sep)
 
   const previewAnnotations = [
     ...(


### PR DESCRIPTION
fix #15.

Should use unified POSIX path as Storybook for Windows.