### PR TITLE
fix: prevent merging the default option of rsbuild-plugin-html-minifier-terser

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -254,14 +254,14 @@ export default async (
     },
     plugins: [
       shouldCheckTs ? pluginTypeCheck(tsCheckOptions) : null,
-      pluginHtmlMinifierTerser({
+      pluginHtmlMinifierTerser(() => ({
         collapseWhitespace: true,
         removeComments: true,
         removeRedundantAttributes: true,
         removeScriptTypeAttributes: false,
         removeStyleLinkTypeAttributes: true,
         useShortDoctype: true,
-      }),
+      })),
     ].filter(Boolean),
     tools: {
       rspack: (config, { addRules, appendPlugins, rspack, mergeConfig }) => {


### PR DESCRIPTION
Fix https://github.com/rspack-contrib/storybook-rsbuild/issues/59.

Fortunately, I supported overwriting configuration through callback functions at that time. 🥹