### PR TITLE
fix: peer dep compat with 1.x version

### DIFF
--- a/packages/builder-rsbuild/package.json
+++ b/packages/builder-rsbuild/package.json
@@ -92,7 +92,7 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta",
+    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta || 1.x",
     "storybook": "^8.2.1"
   },
   "peerDependenciesMeta": {

--- a/packages/react-rsbuild/package.json
+++ b/packages/react-rsbuild/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta",
+    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta || 1.x",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "storybook": "^8.2.1",

--- a/packages/vue3-rsbuild/package.json
+++ b/packages/vue3-rsbuild/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta",
+    "@rsbuild/core": ">= 1.0.0-alpha.9 || >= 1.0.1-beta || 1.x",
     "storybook": "^8.2.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
When 1.x released, it should meets the peer dep requirements.