### PR TITLE
fix(storybook-addon-rslib): use correct file extensions in `exports` object in package.json

### DIFF
--- a/packages/addon-rslib/package.json
+++ b/packages/addon-rslib/package.json
@@ -15,10 +15,12 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "node": "./dist/index.js",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
-    "./preset": "./dist/preset.cjs",
+    "./preset": "./dist/preset.js",
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
# Why

because currently addon doesn't work because the defined `cjs` file doesn't exist in dist

Error when running Storybook

```sh
> storybook dev -p 6006

@storybook/core v8.4.7

WARN Could not resolve addon "storybook-addon-rslib", skipping. Is it installed?
```