### PR TITLE
fix(builder): clear `devServer` field validation warning

### DIFF
--- a/packages/builder-rsbuild/src/index.ts
+++ b/packages/builder-rsbuild/src/index.ts
@@ -74,13 +74,14 @@ const rsbuild = async (_: unknown, options: RsbuildBuilderOptions) => {
     'webpackFinal',
     // TODO: using empty webpack config as base for now. It's better to using the composed rspack
     // config in `iframe-rsbuild.config.ts` as base config. But when `tools.rspack` is an async function,
-    // the following `tools.rspack` raise an ` Promises are not supported` error.
+    // the following `tools.rspack` raise an `Promises are not supported` error.
     {
       output: {},
       module: {},
       plugins: [],
       resolve: {},
-      devServer: {},
+      // https://github.com/web-infra-dev/rsbuild/blob/8dc35dc1d1500d2f119875d46b6a07e27986d532/packages/core/src/provider/rspackConfig.ts#L167
+      devServer: undefined,
       optimization: {},
       performance: {},
       externals: {},


### PR DESCRIPTION
Close https://github.com/rspack-contrib/storybook-rsbuild/issues/254.

Avoid the warning threw from https://github.com/web-infra-dev/rsbuild/blob/8dc35dc1d1500d2f119875d46b6a07e27986d532/packages/core/src/provider/rspackConfig.ts#L167. It should not break anything.

`devServer` field is not supposed to work no matter before or after the PR.