### PR TITLE
chore: enable trusted publishing for npm packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,24 +3,27 @@
 name: Release
 
 permissions:
-  contents: write
+  id-token: write # Required for OIDC
+  contents: read
 
 on: workflow_dispatch
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
-
-      - name: Install Pnpm
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
         run: |
+          npm install -g npm@latest
+          npm --version
           npm install -g corepack@latest --force
           corepack enable
 


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

## Related Links

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

<!--- Provide links of related issues or pages -->