### PR TITLE
fix: move `@types/node` to `devDeps` consistently

### DIFF
--- a/packages/framework-html/package.json
+++ b/packages/framework-html/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.2.0",
     "@storybook/html": "^9.0.18",
-    "@types/node": "^18.19.110",
     "find-up": "^5.0.0",
     "magic-string": "^0.30.17",
     "resolve": "^1.22.10",
@@ -55,6 +54,7 @@
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
     "@storybook/types": "9.0.0-alpha.1",
+    "@types/node": "^18.19.110",
     "@types/resolve": "^1.20.6",
     "storybook": "9.1.2",
     "typescript": "^5.8.3"

--- a/packages/framework-react/package.json
+++ b/packages/framework-react/package.json
@@ -54,7 +54,6 @@
     "@rollup/pluginutils": "^5.2.0",
     "@storybook/react": "^9.0.18",
     "@storybook/react-docgen-typescript-plugin": "^1.0.1",
-    "@types/node": "^18.19.110",
     "find-up": "^5.0.0",
     "magic-string": "^0.30.17",
     "react-docgen": "^7.1.1",
@@ -66,6 +65,7 @@
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
     "@storybook/types": "9.0.0-alpha.1",
+    "@types/node": "^18.19.110",
     "@types/react": "^18.3.23",
     "@types/resolve": "^1.20.6",
     "react": "18.3.1",

--- a/packages/framework-vue3/package.json
+++ b/packages/framework-vue3/package.json
@@ -53,13 +53,13 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
-    "@types/node": "^18.19.110",
     "storybook": "9.1.2",
     "typescript": "^5.8.3",
     "vue": "^3.5.18"
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.1",
+    "@types/node": "^18.19.110",
     "storybook": "^9.0.0",
     "vue": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,6 @@ importers:
       '@storybook/html':
         specifier: ^9.0.18
         version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@6.3.5(@types/node@18.19.110)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.89.1)(stylus@0.59.0)(terser@5.40.0)(tsx@4.20.3)(yaml@2.7.0)))
-      '@types/node':
-        specifier: ^18.19.110
-        version: 18.19.110
       find-up:
         specifier: ^5.0.0
         version: 5.0.0
@@ -230,6 +227,9 @@ importers:
       '@storybook/types':
         specifier: 9.0.0-alpha.1
         version: 9.0.0-alpha.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@6.3.5(@types/node@18.19.110)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.89.1)(stylus@0.59.0)(terser@5.40.0)(tsx@4.20.3)(yaml@2.7.0)))
+      '@types/node':
+        specifier: ^18.19.110
+        version: 18.19.110
       '@types/resolve':
         specifier: ^1.20.6
         version: 1.20.6
@@ -251,9 +251,6 @@ importers:
       '@storybook/react-docgen-typescript-plugin':
         specifier: ^1.0.1
         version: 1.0.1(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.11.31(@swc/helpers@0.5.17)))
-      '@types/node':
-        specifier: ^18.19.110
-        version: 18.19.110
       find-up:
         specifier: ^5.0.0
         version: 5.0.0
@@ -282,6 +279,9 @@ importers:
       '@storybook/types':
         specifier: 9.0.0-alpha.1
         version: 9.0.0-alpha.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@6.3.5(@types/node@18.19.110)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.89.1)(stylus@0.59.0)(terser@5.40.0)(tsx@4.20.3)(yaml@2.7.0)))
+      '@types/node':
+        specifier: ^18.19.110
+        version: 18.19.110
       '@types/react':
         specifier: ^18.3.23
         version: 18.3.23
@@ -306,6 +306,9 @@ importers:
       '@storybook/vue3':
         specifier: ^9.0.18
         version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@6.3.5(@types/node@18.19.110)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.89.1)(stylus@0.59.0)(terser@5.40.0)(tsx@4.20.3)(yaml@2.7.0)))(vue@3.5.18(typescript@5.8.3))
+      '@types/node':
+        specifier: ^18.19.110
+        version: 18.19.110
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
@@ -316,9 +319,6 @@ importers:
       '@rsbuild/core':
         specifier: ^1.4.11
         version: 1.4.11
-      '@types/node':
-        specifier: ^18.19.110
-        version: 18.19.110
       storybook:
         specifier: 9.1.2
         version: 9.1.2(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@6.3.5(@types/node@18.19.110)(jiti@2.5.1)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.89.1)(stylus@0.59.0)(terser@5.40.0)(tsx@4.20.3)(yaml@2.7.0))


### PR DESCRIPTION
Forcing a particular version of `@types/node` can cause unintended upgrades or downgrades of types for users.

Similar to storybookjs/storybook#30163