### PR TITLE
fix(builder): returns empty object instead undefined

### DIFF
--- a/packages/builder-rsbuild/src/react-shims.ts
+++ b/packages/builder-rsbuild/src/react-shims.ts
@@ -70,7 +70,7 @@ export const applyReactShims = async (
 ): Promise<RsbuildConfig | undefined> => {
   const isReactVersion18 = await getIsReactVersion18or19(options)
   if (isReactVersion18) {
-    return undefined
+    return {}
   }
 
   return {


### PR DESCRIPTION
The result of function `applyReactShims` is passing to [rsbuildReal.mergeRsbuildConfig](https://github.com/rspack-contrib/storybook-rsbuild/blob/main/packages/builder-rsbuild/src/index.ts#L104) which then make [destruction](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/src/mergeConfig.ts#L85) when trying normalize config structure. So `undefined` can't be destructed.

Maybe we should add condition and not pass result of `applyReactShims` to `rsbuildReal.mergeRsbuildConfig` if it returns `undefined` or we need to add conditions in [normalizeConfigStructure](normalizeConfigStructure)?
