### PR TITLE
fix: drop usage of appendPlugins to avoid plugins missing

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -261,9 +261,7 @@ export default async (
       })),
     ].filter(Boolean),
     tools: {
-      rspack: (config, { addRules, appendPlugins, rspack, mergeConfig }) => {
-        // TODO: Rspack doesn't support `unknownContextCritical` yet
-        // config.module.unknownContextCritical = false
+      rspack: (config, { addRules, rspack, mergeConfig }) => {
         addRules({
           test: /\.stories\.([tj])sx?$|(stories|story)\.mdx$/,
           exclude: /node_modules/,
@@ -335,8 +333,9 @@ export default async (
           )
         }
 
-        appendPlugins(
-          [
+        config.plugins ??= []
+        config.plugins.push(
+          ...[
             Object.keys(virtualModuleMapping).length > 0
               ? new rspack.experiments.VirtualModulesPlugin(
                   virtualModuleMapping,

--- a/sandboxes/react-16/rsbuild.config.ts
+++ b/sandboxes/react-16/rsbuild.config.ts
@@ -10,4 +10,14 @@ export default defineConfig({
     },
   },
   plugins: [pluginReact()],
+  tools: {
+    rspack: (config) => {
+      const newConfig = {
+        ...config,
+        module: { ...config.module }, // works fine
+        plugins: [...config.plugins], // should also works fine, to test packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts:265
+      }
+      return newConfig
+    },
+  },
 })


### PR DESCRIPTION
fix https://github.com/rspack-contrib/storybook-rsbuild/issues/337. also resolve https://github.com/rspack-contrib/storybook-rsbuild/issues/371 raised by another issue but blocked by the issue here. 