### PR TITLE
docs(faq): add FAQ entry for Template.toString() showing compiled code

### DIFF
--- a/website/docs/guide/faq.mdx
+++ b/website/docs/guide/faq.mdx
@@ -20,6 +20,14 @@ const config: StorybookConfig = {
 }
 ```
 
+## `Template.toString()` shows compiled code in Docs source snippet
+
+When using the CSF 2 `Template.bind({})` pattern and `Template.toString()` to display source code in the Docs addon, the snippet shows bundler-compiled output instead of your original source.
+
+This is expected — `Function.prototype.toString()` serializes the **runtime** function, which has already been transformed by the bundler. This is not specific to the Rsbuild builder; the same happens with webpack and Vite.
+
+Storybook recommends using the [CSF 3 format](https://storybook.js.org/docs/api/csf) with the automatic source snippet feature, or manually providing source code through [docs source parameters](https://storybook.js.org/docs/api/doc-blocks/doc-block-source). See the [Storybook Docs documentation](https://storybook.js.org/docs/writing-docs/autodocs) for more details.
+
 ## Build errors from unexpected files
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- Add a new FAQ entry explaining why `Template.toString()` shows compiled code in Docs source snippets
- This is expected `Function.prototype.toString()` behavior, not specific to the Rsbuild builder
- Link to Storybook's recommended alternatives (CSF 3 format, docs source parameters)

Ref: https://github.com/rstackjs/storybook-rsbuild/issues/224

## Test plan
- [ ] Verify the documentation renders correctly on the website

🤖 Generated with [Claude Code](https://claude.com/claude-code)