### PR TITLE
fix(builder-rsbuild): use relative asset paths for subpath and CDN deployment

### DIFF
--- a/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
@@ -39,8 +39,7 @@ export class RspackInjectMockerRuntimePlugin {
         (data, cb) => {
           try {
             const runtimeScriptContent = getMockerRuntime()
-            // Must suffix with './'.
-            const runtimeAssetName = './mocker-runtime-injected.js'
+            const runtimeAssetName = 'mocker-runtime-injected.js'
 
             const Sources = compiler.webpack?.sources
             if (!Sources?.RawSource) {

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -237,7 +237,7 @@ export default async (
   const rsbuildConfig = mergeRsbuildConfig(contentFromConfig, {
     output: {
       cleanDistPath: false,
-      assetPrefix: '/',
+      assetPrefix: '',
       dataUriLimit: {
         media: 10000,
       },
@@ -266,7 +266,7 @@ export default async (
       publicDir: false,
     },
     dev: {
-      assetPrefix: '/',
+      assetPrefix: '',
       progressBar: !quiet,
       hmr: shouldDisableHmr ? false : undefined,
     },

--- a/packages/builder-rsbuild/templates/preview.ejs
+++ b/packages/builder-rsbuild/templates/preview.ejs
@@ -73,11 +73,9 @@
     <% } %>
     <script type="module">
       import './sb-preview/runtime.js';
-      <%# Diverges from the official webpack5 template which always prepends './',
-          breaking absolute CDN URLs. We preserve absolute URLs as-is to support
-          CDN deployment via assetPrefix. See https://github.com/storybookjs/storybook/issues/23481 %>
+      <%/* Diverges from webpack5 template: preserve absolute/root-relative URLs for CDN deployment (storybookjs/storybook#23481) */%>
       <% htmlWebpackPlugin.files.js.forEach(file => { %>
-      import '<%= file.startsWith("http") || file.startsWith("//") ? file : "./" + file %>';
+      import '<%= /^(https?:)?\//.test(file) ? file : "./" + file %>';
       <% }); %>
     </script>    
   </body>

--- a/packages/builder-rsbuild/templates/preview.ejs
+++ b/packages/builder-rsbuild/templates/preview.ejs
@@ -73,8 +73,11 @@
     <% } %>
     <script type="module">
       import './sb-preview/runtime.js';
+      <%# Diverges from the official webpack5 template which always prepends './',
+          breaking absolute CDN URLs. We preserve absolute URLs as-is to support
+          CDN deployment via assetPrefix. See https://github.com/storybookjs/storybook/issues/23481 %>
       <% htmlWebpackPlugin.files.js.forEach(file => { %>
-      import '<%= file %>';
+      import '<%= file.startsWith("http") || file.startsWith("//") ? file : "./" + file %>';
       <% }); %>
     </script>    
   </body>

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type { Rspack } from '@rsbuild/core'
 import { describe, expect, it, rs } from '@rstest/core'
@@ -20,6 +21,7 @@ type LazyCompilationOption = Rspack.Configuration['lazyCompilation']
 
 const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
+  configType: 'DEVELOPMENT' | 'PRODUCTION' = 'DEVELOPMENT',
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
@@ -75,7 +77,7 @@ const createOptions = (
   } as unknown as Required<RsbuildBuilderOptions>['cache']
 
   const options: Partial<RsbuildBuilderOptions> = {
-    configType: 'DEVELOPMENT',
+    configType,
     quiet: true,
     outputDir: 'storybook-static',
     packageJson: { version: '8.0.0-test' },
@@ -192,6 +194,55 @@ describe('iframe-rsbuild.config', () => {
     expect(appendRules).toHaveBeenCalledWith({
       resourceQuery: /[?&]raw(?:&|=|$)/,
       type: 'asset/source',
+    })
+  })
+
+  // Regression tests for assetPrefix — guards against #66, #72, #75, #224.
+  // The default assetPrefix must be '' (empty string) to produce relative paths,
+  // enabling subpath/CDN deployment without manual config (#224).
+  // Using '/' caused absolute paths that break non-root deployments.
+  // See HANDOFF.md "Failed Approaches" for the full regression chain.
+  describe('assetPrefix defaults to empty string for subpath deployment (#224)', () => {
+    it('sets output.assetPrefix to empty string in dev mode (#72)', async () => {
+      const { options } = createOptions(false, 'DEVELOPMENT')
+      const config = await createIframeRsbuildConfig(
+        options as RsbuildBuilderOptions,
+      )
+      expect(config.output?.assetPrefix).toBe('')
+    })
+
+    it('sets dev.assetPrefix to empty string in dev mode (#72)', async () => {
+      const { options } = createOptions(false, 'DEVELOPMENT')
+      const config = await createIframeRsbuildConfig(
+        options as RsbuildBuilderOptions,
+      )
+      expect(config.dev?.assetPrefix).toBe('')
+    })
+
+    it('sets output.assetPrefix to empty string in production mode (#224)', async () => {
+      const { options } = createOptions(false, 'PRODUCTION')
+      const config = await createIframeRsbuildConfig(
+        options as RsbuildBuilderOptions,
+      )
+      expect(config.output?.assetPrefix).toBe('')
+    })
+  })
+
+  // Regression test for preview.ejs template — guards against #75 and #23481 (webpack5).
+  // - Relative paths (default assetPrefix: '') must get './' prefix so they resolve
+  //   correctly in subdirectory deployments.
+  // - Absolute URLs (CDN assetPrefix like 'http://cdn.example.com/') must NOT get
+  //   './' prefix, which would turn them into broken relative paths.
+  describe('preview.ejs handles import paths correctly', () => {
+    it('prepends "./" for relative paths and preserves absolute URLs', () => {
+      const templatePath = resolve(__dirname, '../../templates/preview.ejs')
+      const template = readFileSync(templatePath, 'utf-8')
+
+      // Must contain conditional logic that adds './' only for relative paths
+      expect(template).toContain('"./" + file')
+      // Must handle http:// and protocol-relative // URLs
+      expect(template).toContain('file.startsWith("http")')
+      expect(template).toContain('file.startsWith("//")')
     })
   })
 })

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -231,18 +231,16 @@ describe('iframe-rsbuild.config', () => {
   // Regression test for preview.ejs template — guards against #75 and #23481 (webpack5).
   // - Relative paths (default assetPrefix: '') must get './' prefix so they resolve
   //   correctly in subdirectory deployments.
-  // - Absolute URLs (CDN assetPrefix like 'http://cdn.example.com/') must NOT get
-  //   './' prefix, which would turn them into broken relative paths.
+  // - Absolute/root-relative URLs must NOT get './' prefix.
   describe('preview.ejs handles import paths correctly', () => {
-    it('prepends "./" for relative paths and preserves absolute URLs', () => {
+    it('prepends "./" only for bare relative paths, preserves absolute and root-relative URLs', () => {
       const templatePath = resolve(__dirname, '../../templates/preview.ejs')
       const template = readFileSync(templatePath, 'utf-8')
 
       // Must contain conditional logic that adds './' only for relative paths
       expect(template).toContain('"./" + file')
-      // Must handle http:// and protocol-relative // URLs
-      expect(template).toContain('file.startsWith("http")')
-      expect(template).toContain('file.startsWith("//")')
+      // Must use a regex that matches http(s)://, //, and root-relative /
+      expect(template).toMatch(/\^.https.*\\\//)
     })
   })
 })

--- a/website/docs/guide/faq.mdx
+++ b/website/docs/guide/faq.mdx
@@ -2,7 +2,15 @@
 
 ## Deploy Storybook to a subdirectory or subpath
 
-The default Vite and webpack builders emit relative asset paths, but Rsbuild recommends absolute paths for deployment (see the [asset prefix tips](https://rsbuild.rs/config/output/asset-prefix#path-types:~:text=on%20file%20location.-,TIP,-It%27s%20not%20recommended)). To deploy Storybook at `https://example.com/sb-path`, set [`output.assetPrefix`](https://rsbuild.rs/config/output/asset-prefix).
+> Since v3.3.3. In v3.3.2 and earlier, the default `assetPrefix` was `'/'` (absolute), which required manual configuration for subdirectory deployment.
+
+The Rsbuild builder uses relative asset paths by default — the same as the official Vite (`base: './'`) and webpack (`publicPath: ''`) builders. Storybook can be deployed to any subdirectory (e.g., `https://example.com/storybook/`) without extra configuration.
+
+## Serving static assets from a CDN
+
+> Since v3.3.3. In v3.3.2 and earlier, this was not supported.
+
+To serve Storybook's JS/CSS bundles from a separate CDN origin (e.g., `https://cdn.example.com/assets/`), set [`output.assetPrefix`](https://rsbuild.rs/config/output/asset-prefix) to the CDN URL:
 
 ```js
 import { mergeRsbuildConfig } from '@rsbuild/core'
@@ -12,13 +20,45 @@ const config: StorybookConfig = {
   rsbuildFinal: (config) => {
     return mergeRsbuildConfig(config, {
       output: {
-        assetPrefix: '/sb-path/',
+        assetPrefix: 'https://cdn.example.com/',
       },
     })
   },
   // --snip--
 }
 ```
+
+The preview template correctly handles absolute URLs, so JS/CSS bundles will be loaded from the CDN while `iframe.html` can remain on the origin server. Note that the CDN must serve appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) since the bundles are loaded via ES module imports.
+
+> [!NOTE]
+> This is an improvement over the [official webpack5 builder](https://github.com/storybookjs/storybook/issues/23481), which does not support CDN asset hosting due to its template always prepending `./` to import paths.
+
+## CSS `url()` references to static assets
+
+> In v3.3.2 and earlier, CSS `url()` worked correctly when served from the root path because the default `assetPrefix` was `'/'`. Since v3.3.3, the default changed to `''` (relative) for subdirectory support, which introduces this limitation.
+
+When CSS files reference other assets via `url()` (e.g., `background: url('./image.png')`), the generated paths may resolve incorrectly in the production build. This happens because Rspack emits `url()` paths relative to the output root, but the browser resolves them relative to the CSS file's location. This is a known trade-off of using relative paths, and the [official Storybook builders have the same limitation](https://github.com/storybookjs/storybook/issues/23447).
+
+If your stories rely on CSS `url()` references, you can switch to absolute paths via [`output.assetPrefix`](https://rsbuild.rs/config/output/asset-prefix):
+
+```js
+import { mergeRsbuildConfig } from '@rsbuild/core'
+
+const config: StorybookConfig = {
+  // --snip--
+  rsbuildFinal: (config) => {
+    return mergeRsbuildConfig(config, {
+      output: {
+        assetPrefix: '/',
+      },
+    })
+  },
+  // --snip--
+}
+```
+
+> [!NOTE]
+> Setting `assetPrefix: '/'` fixes CSS `url()` references when served from the root path, but breaks subdirectory deployment. Choose the option that fits your deployment scenario.
 
 ## `Template.toString()` shows compiled code in Docs source snippet
 


### PR DESCRIPTION
## Summary

- Change default `assetPrefix` from `'/'` to `''` (both `output` and `dev`), aligning with the official Vite (`base: './'`) and webpack5 (`publicPath: ''`) builders
- Update `preview.ejs` to intelligently handle both relative paths (prepends `./`) and absolute CDN URLs (preserves as-is), fixing [storybookjs/storybook#23481](https://github.com/storybookjs/storybook/issues/23481) for the Rsbuild builder
- Remove redundant `./` prefix from mocker runtime plugin asset name
- Add 4 regression tests guarding against #66, #72, #75, #224
- Update FAQ with version-specific docs for subdirectory deployment, CDN hosting, and CSS `url()` trade-off

### Breaking behavior change (v3.3.2 → v3.3.3)

| Scenario | v3.3.2 (`assetPrefix: '/'`) | v3.3.3 (`assetPrefix: ''`) |
|---|---|---|
| Root path deployment | ✅ | ✅ |
| Subdirectory deployment | ❌ needs manual config | ✅ works out of the box |
| CDN asset hosting | ❌ not supported | ✅ via `rsbuildFinal` |
| CSS `url()` references | ✅ works from root | ⚠️ [known limitation](https://github.com/storybookjs/storybook/issues/23447), workaround in FAQ |

## Test plan

- [x] `pnpm test` — 11 unit tests pass (including 4 new regression tests)
- [x] `pnpm build` — all packages build
- [x] `pnpm build:sandboxes` — all 12 sandboxes build
- [x] Subdirectory deployment verified via static server at `/my-docs/storybook/`
- [x] CDN split deployment verified via dual-origin static servers (HTML on origin, JS/CSS on CDN port)
- [x] Browser verification: Button CSS, Page story, full Storybook UI all render correctly

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)