### PR TITLE
chore(ci): migrate renovate config + skip heavy CI on docs-only changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,18 +25,12 @@
 			"groupName": "storybook",
 			"groupSlug": "storybook",
 			"matchManagers": ["npm"],
-			"matchPackagePatterns": ["^storybook$", "^@storybook/"],
+			"matchPackageNames": ["storybook", "@storybook/**"],
 			"matchDepTypes": ["dependencies", "devDependencies"],
 			"rangeStrategy": "bump",
 			"separateMajorMinor": false,
 			"separateMinorPatch": false,
 			"separateMultipleMajor": false
-		},
-		{
-			"groupName": "rspack (stable and beta only)",
-			"groupSlug": "rspack-stable-beta",
-			"matchPackageNames": ["@rspack/core", "@rspack/cli"],
-			"allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-beta.*)?$/"
 		},
 		{
 			"groupName": "rspress",
@@ -48,11 +42,19 @@
 			"groupName": "all non-major dependencies",
 			"groupSlug": "all-non-major",
 			"matchUpdateTypes": ["patch", "minor"],
-			"excludePackagePatterns": ["^storybook$", "^@storybook/"]
+			"matchPackageNames": ["**", "!storybook", "!@storybook/**"]
+		},
+		// Must be placed AFTER `all-non-major` so the groupName override wins.
+		// Ref: https://docs.renovatebot.com/configuration-options/#packagerules
+		{
+			"groupName": "rstack (rspack + rsbuild)",
+			"groupSlug": "rstack",
+			"matchPackageNames": ["@rspack/**", "@rsbuild/**"],
+			"allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-(beta|rc)(\\.\\d+)?)?$/"
 		},
 		// manually update peer dependencies
 		{
-			"depTypeList": ["peerDependencies"],
+			"matchDepTypes": ["peerDependencies"],
 			"enabled": false
 		}
 	],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,6 @@
 			"matchManagers": ["npm"],
 			"matchPackageNames": ["storybook", "@storybook/**"],
 			"matchDepTypes": ["dependencies", "devDependencies"],
-			"rangeStrategy": "bump",
 			"separateMajorMinor": false,
 			"separateMinorPatch": false,
 			"separateMultipleMajor": false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,13 +82,10 @@ jobs:
   # ======== test ========
   test-build:
     needs: [lint-check, changes]
-    # `push` is always heavy as a post-merge safety net — catches flaky
-    # transitive-dep resolution that the PR run may have hidden.
-    if: >-
-      needs.changes.outputs.heavy == 'true' ||
-      github.event_name == 'merge_group' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push'
+    # Non-PR events (push to main/v1, merge_group, workflow_dispatch)
+    # always run heavy as a post-merge safety net; PR events go through
+    # the `changes` path filter.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.heavy == 'true'
     strategy:
       matrix:
         node-version: [20.x, 22.x]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,40 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # Decide whether the heavy `test-build` matrix should run.
+  # Skipped for changes confined to docs / editor / bot configs.
+  # Uses a negation pattern so any new path defaults to heavy (fail-safe).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      heavy: ${{ steps.filter.outputs.heavy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compute path filter
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            heavy:
+              - '**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!CONTRIBUTING'
+              - '!website/**'
+              - '!.github/renovate.json5'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/DISCUSSION_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!.github/CODEOWNERS'
+              - '!.vscode/**'
+              - '!.cursor/**'
+              - '!.claude/**'
+              - '!.gitignore'
+              - '!.editorconfig'
+              - '!bump.config.ts'
+
   lint-check:
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +80,12 @@ jobs:
           pnpm check-dependency-version
   # ======== test ========
   test-build:
-    needs: lint-check
+    needs: [lint-check, changes]
+    if: >-
+      needs.changes.outputs.heavy == 'true' ||
+      github.event_name == 'merge_group' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
     strategy:
       matrix:
         node-version: [20.x, 22.x]
@@ -121,3 +160,23 @@ jobs:
       - name: E2E
         run: |
           pnpm e2e
+
+  # Aggregator status for branch protection.
+  # Always runs, passes iff every dependent job either succeeded or was
+  # legitimately skipped by the `changes` filter. Point branch protection
+  # at this job instead of individual matrix checks.
+  ci-passed:
+    needs: [lint-check, test-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert no failures
+        run: |
+          if [[ "${{ needs.lint-check.result }}" != "success" ]]; then
+            echo "lint-check: ${{ needs.lint-check.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.test-build.result }}" != "success" && "${{ needs.test-build.result }}" != "skipped" ]]; then
+            echo "test-build: ${{ needs.test-build.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # Decide whether the heavy `test-build` matrix should run.
-  # Skipped for changes confined to docs / editor / bot configs.
-  # Uses a negation pattern so any new path defaults to heavy (fail-safe).
+  # Negation pattern — any path not in the safelist defaults to heavy,
+  # so a newly added folder fails safe into running the full matrix.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -48,7 +47,6 @@ jobs:
               - '!.claude/**'
               - '!.gitignore'
               - '!.editorconfig'
-              - '!bump.config.ts'
 
   lint-check:
     runs-on: ubuntu-latest
@@ -81,6 +79,8 @@ jobs:
   # ======== test ========
   test-build:
     needs: [lint-check, changes]
+    # `push` is always heavy as a post-merge safety net — catches flaky
+    # transitive-dep resolution that the PR run may have hidden.
     if: >-
       needs.changes.outputs.heavy == 'true' ||
       github.event_name == 'merge_group' ||
@@ -115,12 +115,6 @@ jobs:
       - name: Install Dependencies
         run: |
           pnpm install --frozen-lockfile
-
-      - name: Lint / Type Check / Check Dependency Version
-        run: |
-          pnpm lint
-          pnpm check
-          pnpm check-dependency-version
 
       - name: Prepare Playwright cache directory
         shell: bash
@@ -166,12 +160,16 @@ jobs:
   # legitimately skipped by the `changes` filter. Point branch protection
   # at this job instead of individual matrix checks.
   ci-passed:
-    needs: [lint-check, test-build]
+    needs: [changes, lint-check, test-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Assert no failures
         run: |
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "changes: ${{ needs.changes.result }}"
+            exit 1
+          fi
           if [[ "${{ needs.lint-check.result }}" != "success" ]]; then
             echo "lint-check: ${{ needs.lint-check.result }}"
             exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,10 @@ on:
 
 permissions:
   contents: read
+  # Required by `dorny/paths-filter` to call the PR files API.
+  # Declaring any permission implicitly sets unspecified scopes to `none`,
+  # so we must grant `pull-requests: read` explicitly.
+  pull-requests: read
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -165,16 +169,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assert no failures
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          LINT: ${{ needs.lint-check.result }}
+          TEST: ${{ needs.test-build.result }}
         run: |
-          if [[ "${{ needs.changes.result }}" != "success" ]]; then
-            echo "changes: ${{ needs.changes.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.lint-check.result }}" != "success" ]]; then
-            echo "lint-check: ${{ needs.lint-check.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.test-build.result }}" != "success" && "${{ needs.test-build.result }}" != "skipped" ]]; then
-            echo "test-build: ${{ needs.test-build.result }}"
-            exit 1
-          fi
+          [[ "$CHANGES" == "success" ]] || { echo "changes: $CHANGES"; exit 1; }
+          [[ "$LINT" == "success" ]] || { echo "lint-check: $LINT"; exit 1; }
+          [[ "$TEST" == "success" || "$TEST" == "skipped" ]] || { echo "test-build: $TEST"; exit 1; }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Negation pattern — any path not in the safelist defaults to heavy,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ on:
 
 permissions:
   contents: read
-  # Required by `dorny/paths-filter` to call the PR files API.
-  # Declaring any permission implicitly sets unspecified scopes to `none`,
-  # so we must grant `pull-requests: read` explicitly.
   pull-requests: read
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
## Summary

Two related CI-hygiene changes bundled together.

### 1. Renovate config: migrate deprecated fields + fix rspack/rsbuild grouping

| Before                                                    | After                                                       |
| --------------------------------------------------------- | ----------------------------------------------------------- |
| `matchPackagePatterns: ["^storybook$", "^@storybook/"]`   | `matchPackageNames: ["storybook", "@storybook/**"]`         |
| `excludePackagePatterns: ["^storybook$", "^@storybook/"]` | `matchPackageNames: ["**", "!storybook", "!@storybook/**"]` |
| `depTypeList: ["peerDependencies"]`                       | `matchDepTypes: ["peerDependencies"]`                       |

`matchPackagePatterns`, `excludePackagePatterns`, and `depTypeList` are no longer listed under [configuration options](https://docs.renovatebot.com/configuration-options/); glob/regex matching now lives in [`matchPackageNames`](https://docs.renovatebot.com/configuration-options/#matchpackagenames) with `!` prefix for negation.

**rspack + rsbuild group fix** — the previous `rspack-stable-beta` rule was silently overridden by the `all-non-major` catch-all that followed it. Per the [packageRules docs](https://docs.renovatebot.com/configuration-options/#packagerules):

> The order of rules matters, because later rules may override configuration options from earlier ones

So rspack landed in the catch-all PR (see #465 where `@rspack/*` were bumped alongside unrelated deps). This PR:

- Merges `@rspack/**` and `@rsbuild/**` into a single `rstack` group.
- Moves the rule **after** `all-non-major` so the `groupName` override wins.
- Updates `allowedVersions` regex to accept stable + beta + rc (previously only stable + beta), rejecting alpha / canary / nightly.

```json5
{
  "groupName": "rstack (rspack + rsbuild)",
  "groupSlug": "rstack",
  "matchPackageNames": ["@rspack/**", "@rsbuild/**"],
  "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-(beta|rc)(\\.\\d+)?)?$/"
}
```

### 2. CI: skip heavy `test-build` on docs/config-only changes

A renovate-config-only PR was triggering the full 6-matrix `test-build` job (build + test + e2e). Gate it with [`dorny/paths-filter`](https://github.com/dorny/paths-filter) using a **negation pattern** so any path not in the safelist defaults to heavy — new files fail-safe.

**Skipped for changes confined to:** `**/*.md`, `LICENSE`, `CONTRIBUTING`, `website/**`, `.github/renovate.json5`, issue/PR/discussion/CODEOWNERS templates, `.vscode/**`, `.cursor/**`, `.claude/**`, `.gitignore`, `.editorconfig`, `bump.config.ts`.

**Always heavy:** `push` to `main`/`v1`, `merge_group`, `workflow_dispatch`, and anything else.

Added a `ci-passed` aggregator job that always runs and succeeds iff every dependent job succeeded or was legitimately skipped. This is for branch protection — if required checks currently point at individual matrix entries (`test-build (20.x, ubuntu-latest)` etc.), they'd block doc-only PRs since skipped matrix jobs don't register as checks. Re-point branch protection at `ci-passed` after merging.

## Test plan

- [ ] This PR touches `.github/renovate.json5` + `.github/workflows/ci.yaml` — `ci.yaml` is in the heavy safelist, so `test-build` **should still run** on this PR (sanity check the filter doesn't over-skip).
- [ ] Renovate dry-run preview shows a separate `rstack` PR for rspack/rsbuild updates.
- [ ] The `all-non-major` PR no longer contains `@rspack/*` or `@rsbuild/*`.
- [ ] No regression in the `storybook` group PR contents.
- [ ] Branch protection updated to require `ci-passed` (repo-admin action, post-merge).