### PR TITLE
fix: repair broken documentation links

### DIFF
--- a/website/docs/guide/configuration.mdx
+++ b/website/docs/guide/configuration.mdx
@@ -182,4 +182,4 @@ const config: StorybookConfig = {
 export default config;
 ```
 
-See [Storybook TypeScript Docs](https://storybook.js.org/docs/configure/typescript) for general TypeScript configuration.
+See [Storybook TypeScript Docs](https://storybook.js.org/docs/configure/integration/typescript) for general TypeScript configuration.

--- a/website/docs/guide/framework/react.mdx
+++ b/website/docs/guide/framework/react.mdx
@@ -45,7 +45,7 @@ const config: StorybookConfig = {
 export default config
 ```
 
-That's it! Explore the [React 16](https://github.com/rstackjs/storybook-rsbuild/blob/main/sandboxes/react-16) and [React 18](https://github.com/rstackjs/storybook-rsbuild/blob/main/sandboxes/react-18) sandboxes for full examples, and continue learning from the [Storybook documentation](https://storybook.js.org/docs).
+That's it! Explore the [React 16](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/react-16) and [React 18](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/react-18) sandboxes for full examples, and continue learning from the [Storybook documentation](https://storybook.js.org/docs).
 
 ## Next Steps
 

--- a/website/docs/guide/framework/vanilla.mdx
+++ b/website/docs/guide/framework/vanilla.mdx
@@ -44,7 +44,7 @@ const config: StorybookConfig = {
 export default config
 ```
 
-You're all set! Review the [vanilla TypeScript sandbox](https://github.com/rstackjs/storybook-rsbuild/blob/main/sandboxes/vanilla-ts) to see the setup in action, and continue exploring the [Storybook docs](https://storybook.js.org/docs).
+You're all set! Review the [vanilla TypeScript sandbox](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/vanilla-ts) to see the setup in action, and continue exploring the [Storybook docs](https://storybook.js.org/docs).
 
 ## Next Steps
 

--- a/website/docs/guide/framework/vue.mdx
+++ b/website/docs/guide/framework/vue.mdx
@@ -45,14 +45,14 @@ const config: StorybookConfig = {
 export default config
 ```
 
-You're ready to go! Check the [Vue 3 sandbox](https://github.com/rstackjs/storybook-rsbuild/blob/main/sandboxes/vue3) for a complete reference, and explore the [Storybook docs](https://storybook.js.org/docs) for feature guides.
+You're ready to go! Check the [Vue 3 sandbox](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/vue3) for a complete reference, and explore the [Storybook docs](https://storybook.js.org/docs) for feature guides.
 
 ## Next Steps
 
 Now that Storybook is running, explore how to create stories for your Vue components:
 
 - **[Writing Stories](https://storybook.js.org/docs/writing-stories)**: Learn the Component Story Format (CSF).
-- **[Vue Essentials](https://storybook.js.org/docs/get-started/vue)**: Specific guides for Vue development in Storybook.
+- **[Vue Essentials](https://storybook.js.org/docs/get-started/frameworks/vue3-vite)**: Specific guides for Vue development in Storybook.
 
 ## Options
 

--- a/website/docs/guide/framework/web-components.mdx
+++ b/website/docs/guide/framework/web-components.mdx
@@ -45,12 +45,12 @@ const config: StorybookConfig = {
 export default config
 ```
 
-You're good to go! See the [web components sandbox](https://github.com/rstackjs/storybook-rsbuild/blob/main/sandboxes/web-components) for a complete reference and browse the [Storybook docs](https://storybook.js.org/docs) for deeper guidance.
+You're good to go! See the [web components sandbox](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/lit) for a complete reference and browse the [Storybook docs](https://storybook.js.org/docs) for deeper guidance.
 
 ## Next Steps
 
 - **[Writing Stories](https://storybook.js.org/docs/writing-stories)**: Learn the basics of CSF for Web Components.
-- **[Lit Snippets](https://storybook.js.org/docs/get-started/web-components)**: Examples using Lit and generic Web Components.
+- **[Lit Snippets](https://storybook.js.org/docs/get-started/frameworks/web-components-vite)**: Examples using Lit and generic Web Components.
 
 ## Options
 

--- a/website/docs/guide/index.mdx
+++ b/website/docs/guide/index.mdx
@@ -40,7 +40,7 @@ The `main` branch ships the Storybook v10 Rsbuild builder together with each fra
 Storybook Rsbuild allows you to use [Rsbuild](https://rsbuild.rs) as the build engine for Storybook, providing faster startup and build times.
 
 :::tip Using an AI coding agent?
-If you use [Claude Code](https://code.claude.com), [Codex](https://openai.com/index/codex/), [OpenCode](https://opencode.ai), or other AI coding agents, install our agent skills for guided setup and migration:
+If you use [Claude Code](https://code.claude.com), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), or other AI coding agents, install our agent skills for guided setup and migration:
 
 <PackageManagerTabs command="skills add rstackjs/agent-skills --skill storybook-rsbuild" dlx />
 
@@ -63,7 +63,7 @@ npm create rsbuild@latest
 npx storybook@latest init
 ```
 
-Storybook will detect Rsbuild and automatically configure `storybook-builder-rsbuild` for you. It will also add example stories to your project. To understand the generated files, check the [Storybook Project Structure](https://storybook.js.org/docs/configure/sidebar-and-urls).
+Storybook will detect Rsbuild and automatically configure `storybook-builder-rsbuild` for you. It will also add example stories to your project. To understand the generated files, check the [Storybook Project Structure](https://storybook.js.org/docs/configure/user-interface/sidebar-and-urls).
 
 ### Existing Project
 
@@ -75,13 +75,13 @@ See the **[Frameworks](/guide/framework/react)** section for detailed migration 
 
 | Package                                                                                                                             | What it provides                                       |
 | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| [storybook-builder-rsbuild](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/builder-rsbuild)                 | The Rsbuild-powered Storybook builder                  |
-| [storybook-react-rsbuild](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/framework-react)                   | React framework integration configured for Rsbuild     |
-| [storybook-vue3-rsbuild](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/framework-vue3)                     | Vue 3 framework integration configured for Rsbuild     |
-| [storybook-html-rsbuild](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/framework-html)                     | Vanilla JavaScript/TypeScript integration              |
-| [storybook-web-components-rsbuild](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/framework-web-components) | Lit and Web Components integration                     |
-| [storybook-addon-rslib](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/addon-rslib)                         | Addon that reuses Rslib configuration inside Storybook |
-| [storybook-addon-modernjs](https://github.com/rstackjs/storybook-rsbuild/blob/main/packages/addon-modernjs)                   | Addon that reuses Modern.js configuration inside Storybook |
+| [storybook-builder-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/builder-rsbuild)                 | The Rsbuild-powered Storybook builder                  |
+| [storybook-react-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/framework-react)                   | React framework integration configured for Rsbuild     |
+| [storybook-vue3-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/framework-vue3)                     | Vue 3 framework integration configured for Rsbuild     |
+| [storybook-html-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/framework-html)                     | Vanilla JavaScript/TypeScript integration              |
+| [storybook-web-components-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/framework-web-components) | Lit and Web Components integration                     |
+| [storybook-addon-rslib](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/addon-rslib)                         | Addon that reuses Rslib configuration inside Storybook |
+| [storybook-addon-modernjs](https://github.com/rstackjs/storybook-rsbuild/tree/main/packages/addon-modernjs)                   | Addon that reuses Modern.js configuration inside Storybook |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Fixes broken documentation links across the website docs.

- Point the Web Components sandbox link at the existing Lit sandbox.
- Use GitHub `tree/main` URLs for repository directories instead of `blob/main`.
- Update migrated Storybook docs URLs and the Codex URL.

## Validation

- Ran a static link checker over `website/docs` and `website/rspress.config.ts`: 20 files, 129 links, 0 findings for local routes, anchors, relative paths, and GitHub repo paths.
- Ran `git diff --check`.
- Could not run `pnpm --filter website build` because this workspace has no `node_modules`; `rspress` is not installed locally.

Closes #475.
