### PR TITLE
fix(builder-rsbuild): auto-disable lazy compilation when MSW is detected

### DIFF
--- a/packages/builder-rsbuild/src/preview/detect-msw.ts
+++ b/packages/builder-rsbuild/src/preview/detect-msw.ts
@@ -1,26 +1,33 @@
+import { existsSync } from 'node:fs'
+import { isAbsolute, resolve } from 'node:path'
 import type { Options, StorybookConfigRaw } from 'storybook/internal/types'
 
-const MSW_ADDON_BASENAME = 'msw-storybook-addon'
+const MSW_SW_FILE = 'mockServiceWorker.js'
 
 /**
- * Detect whether the current Storybook setup integrates MSW via
- * `msw-storybook-addon`. Used to opt out of lazy compilation when MSW is
- * present, because the Service Worker races with the dev-server lazy
- * compilation RPC (`/lazy-compilation-using-*`) and can leave the preview
- * iframe blank.
+ * Detect whether the current Storybook setup serves MSW's Service Worker.
+ * We probe each entry in `staticDirs` for `mockServiceWorker.js`, which is
+ * present whenever the user has run `msw init`. This is a stable signal
+ * regardless of whether MSW is wired via `msw-storybook-addon` or set up
+ * manually in `preview.*`.
+ *
+ * The `addons` preset field cannot be used here: Storybook's `loadPreset`
+ * destructures `addons` out of each preset's exports and recursively loads
+ * them as sub-presets, so `presets.apply('addons', [])` never yields the
+ * addon names declared in `main.*` — it only reflects later-preset
+ * contributions, which excludes user-level `msw-storybook-addon`.
  */
-export async function isMswAddonEnabled(options: Options): Promise<boolean> {
-  const addons = await options.presets.apply<StorybookConfigRaw['addons']>(
-    'addons',
-    [],
-  )
-  return (addons ?? []).some((entry) => {
-    const name =
-      typeof entry === 'string'
-        ? entry
-        : ((entry as { name?: string })?.name ?? '')
-    if (!name) return false
-    const basename = name.split(/[\\/]/).pop() ?? name
-    return basename === MSW_ADDON_BASENAME
+export async function isMswActive(options: Options): Promise<boolean> {
+  const staticDirs = await options.presets.apply<
+    StorybookConfigRaw['staticDirs']
+  >('staticDirs', [])
+
+  if (!Array.isArray(staticDirs)) return false
+
+  return staticDirs.some((entry) => {
+    const dir = typeof entry === 'string' ? entry : entry?.from
+    if (typeof dir !== 'string' || dir.length === 0) return false
+    const abs = isAbsolute(dir) ? dir : resolve(options.configDir, dir)
+    return existsSync(resolve(abs, MSW_SW_FILE))
   })
 }

--- a/packages/builder-rsbuild/src/preview/detect-msw.ts
+++ b/packages/builder-rsbuild/src/preview/detect-msw.ts
@@ -1,0 +1,26 @@
+import type { Options, StorybookConfigRaw } from 'storybook/internal/types'
+
+const MSW_ADDON_BASENAME = 'msw-storybook-addon'
+
+/**
+ * Detect whether the current Storybook setup integrates MSW via
+ * `msw-storybook-addon`. Used to opt out of lazy compilation when MSW is
+ * present, because the Service Worker races with the dev-server lazy
+ * compilation RPC (`/lazy-compilation-using-*`) and can leave the preview
+ * iframe blank.
+ */
+export async function isMswAddonEnabled(options: Options): Promise<boolean> {
+  const addons = await options.presets.apply<StorybookConfigRaw['addons']>(
+    'addons',
+    [],
+  )
+  return (addons ?? []).some((entry) => {
+    const name =
+      typeof entry === 'string'
+        ? entry
+        : ((entry as { name?: string })?.name ?? '')
+    if (!name) return false
+    const basename = name.split(/[\\/]/).pop() ?? name
+    return basename === MSW_ADDON_BASENAME
+  })
+}

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -13,10 +13,12 @@ import {
   normalizeStories,
   stringifyProcessEnvs,
 } from 'storybook/internal/common'
+import { logger } from 'storybook/internal/node-logger'
 import { globalsNameReferenceMap } from 'storybook/internal/preview/globals'
 import type { Options } from 'storybook/internal/types'
 import { dedent } from 'ts-dedent'
 import type { BuilderOptions, TypescriptOptions } from '../types'
+import { isMswAddonEnabled } from './detect-msw'
 import { getVirtualModules } from './virtual-module-mapping'
 
 const require = createRequire(import.meta.url)
@@ -159,13 +161,25 @@ export default async (
   if (!isProd) {
     if (shouldDisableDevFeatures) {
       lazyCompilationConfig = false
+    } else if (builderOptions.lazyCompilation !== undefined) {
+      lazyCompilationConfig = builderOptions.lazyCompilation
+    } else if (await isMswAddonEnabled(options)) {
+      // MSW's Service Worker intercepts the dev-server lazy-compilation RPC
+      // (`/lazy-compilation-using-*`) and aborts its cloned fetch, which can
+      // leave the preview iframe blank on cold story loads. Disable lazy
+      // compilation by default when MSW is integrated; users can opt back in
+      // by setting `lazyCompilation` explicitly.
+      // https://storybook.rsbuild.rs/guide/troubleshooting#msw-integration-and-lazy-compilation
+      lazyCompilationConfig = false
+      logger.warn(dedent`
+        Detected msw-storybook-addon. Lazy compilation has been disabled automatically to
+        avoid a Service Worker race that can leave the preview iframe blank on cold story
+        loads. Set \`lazyCompilation\` explicitly in your builder options to override.
+      `)
     } else {
-      lazyCompilationConfig =
-        builderOptions.lazyCompilation === undefined
-          ? {
-              entries: false,
-            }
-          : builderOptions.lazyCompilation
+      lazyCompilationConfig = {
+        entries: false,
+      }
     }
   }
 

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -18,7 +18,7 @@ import { globalsNameReferenceMap } from 'storybook/internal/preview/globals'
 import type { Options } from 'storybook/internal/types'
 import { dedent } from 'ts-dedent'
 import type { BuilderOptions, TypescriptOptions } from '../types'
-import { isMswAddonEnabled } from './detect-msw'
+import { isMswActive } from './detect-msw'
 import { getVirtualModules } from './virtual-module-mapping'
 
 const require = createRequire(import.meta.url)
@@ -163,18 +163,14 @@ export default async (
       lazyCompilationConfig = false
     } else if (builderOptions.lazyCompilation !== undefined) {
       lazyCompilationConfig = builderOptions.lazyCompilation
-    } else if (await isMswAddonEnabled(options)) {
-      // MSW's Service Worker intercepts the dev-server lazy-compilation RPC
-      // (`/lazy-compilation-using-*`) and aborts its cloned fetch, which can
-      // leave the preview iframe blank on cold story loads. Disable lazy
-      // compilation by default when MSW is integrated; users can opt back in
-      // by setting `lazyCompilation` explicitly.
+    } else if (await isMswActive(options)) {
       // https://storybook.rsbuild.rs/guide/troubleshooting#msw-integration-and-lazy-compilation
       lazyCompilationConfig = false
       logger.warn(dedent`
-        Detected msw-storybook-addon. Lazy compilation has been disabled automatically to
-        avoid a Service Worker race that can leave the preview iframe blank on cold story
-        loads. Set \`lazyCompilation\` explicitly in your builder options to override.
+        Detected mockServiceWorker.js in staticDirs. Lazy compilation has been disabled
+        automatically to avoid a Service Worker race that can leave the preview iframe
+        blank on cold story loads. Set \`lazyCompilation\` explicitly in your builder
+        options to override.
       `)
     } else {
       lazyCompilationConfig = {

--- a/packages/builder-rsbuild/tests/fixtures/msw-absent/.storybook/main.cjs
+++ b/packages/builder-rsbuild/tests/fixtures/msw-absent/.storybook/main.cjs
@@ -1,0 +1,7 @@
+/** @type {import('storybook/internal/types').StorybookConfig} */
+const config = {
+  stories: [],
+  staticDirs: ['../public'],
+}
+
+module.exports = config

--- a/packages/builder-rsbuild/tests/fixtures/msw-active/.storybook/main.cjs
+++ b/packages/builder-rsbuild/tests/fixtures/msw-active/.storybook/main.cjs
@@ -1,0 +1,7 @@
+/** @type {import('storybook/internal/types').StorybookConfig} */
+const config = {
+  stories: [],
+  staticDirs: ['../public'],
+}
+
+module.exports = config

--- a/packages/builder-rsbuild/tests/fixtures/msw-active/public/mockServiceWorker.js
+++ b/packages/builder-rsbuild/tests/fixtures/msw-active/public/mockServiceWorker.js
@@ -1,0 +1,1 @@
+// Test fixture: empty placeholder for MSW service worker detection.

--- a/packages/builder-rsbuild/tests/preview/detect-msw.test.ts
+++ b/packages/builder-rsbuild/tests/preview/detect-msw.test.ts
@@ -1,0 +1,51 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from '@rstest/core'
+import { loadAllPresets } from 'storybook/internal/common'
+import type { Options } from 'storybook/internal/types'
+import { isMswActive } from '../../src/preview/detect-msw'
+
+// Uses real loadAllPresets rather than a mocked apply stub so the preset chain
+// actually passes staticDirs through. See detect-msw.ts for why the `addons`
+// field cannot be observed this way.
+
+const fixtureRoot = resolve(__dirname, '../fixtures')
+
+async function buildOptions(fixture: 'msw-active' | 'msw-absent') {
+  const configDir = resolve(fixtureRoot, fixture, '.storybook')
+  const presets = await loadAllPresets({
+    configDir,
+    outputDir: resolve(fixtureRoot, fixture, 'storybook-static'),
+    ignorePreview: true,
+    corePresets: [],
+    overridePresets: [],
+    packageJson: {},
+  } as unknown as Parameters<typeof loadAllPresets>[0])
+
+  return { configDir, presets }
+}
+
+describe('isMswActive (real Storybook presets)', () => {
+  it('returns true when mockServiceWorker.js exists in a staticDirs entry', async () => {
+    const { configDir, presets } = await buildOptions('msw-active')
+    const options = { configDir, presets } as unknown as Options
+    await expect(isMswActive(options)).resolves.toBe(true)
+  })
+
+  it('returns false when staticDirs is declared but mockServiceWorker.js is absent', async () => {
+    const { configDir, presets } = await buildOptions('msw-absent')
+    const options = { configDir, presets } as unknown as Options
+    await expect(isMswActive(options)).resolves.toBe(false)
+  })
+
+  it('returns false when staticDirs is empty', async () => {
+    // Drive the contract shape without going through loadAllPresets so we
+    // can assert the defensive-default branch.
+    const options = {
+      configDir: resolve(fixtureRoot, 'msw-active', '.storybook'),
+      presets: {
+        apply: async <T>(_name: string, fallback?: T) => fallback,
+      },
+    } as unknown as Options
+    await expect(isMswActive(options)).resolves.toBe(false)
+  })
+})

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -22,7 +22,6 @@ type LazyCompilationOption = Rspack.Configuration['lazyCompilation']
 const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
   configType: 'DEVELOPMENT' | 'PRODUCTION' = 'DEVELOPMENT',
-  addons: unknown[] = [],
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
@@ -57,7 +56,6 @@ const createOptions = (
     ['tags', {}],
     ['build', { test: {} }],
     ['previewAnnotations', []],
-    ['addons', addons],
   ])
 
   const apply = rs.fn(
@@ -141,9 +139,8 @@ describe('iframe-rsbuild.config', () => {
 
   const runRspackTool = async (
     lazyCompilation: LazyCompilationOption | 'unset',
-    addons: unknown[] = [],
   ) => {
-    const { options } = createOptions(lazyCompilation, 'DEVELOPMENT', addons)
+    const { options } = createOptions(lazyCompilation)
     const config = await createIframeRsbuildConfig(
       options as RsbuildBuilderOptions,
     )
@@ -188,31 +185,6 @@ describe('iframe-rsbuild.config', () => {
   it('passes through lazyCompilation options object', async () => {
     const { rspackConfig } = await runRspackTool({ entries: true })
     expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
-  })
-
-  // MSW's Service Worker races with the dev-server lazy-compilation RPC and
-  // leaves the preview iframe blank on cold story loads. Default-off when the
-  // addon is present; respect an explicit user override.
-  it('disables lazyCompilation when msw-storybook-addon is present and option is unset', async () => {
-    const { rspackConfig } = await runRspackTool('unset', [
-      'msw-storybook-addon',
-    ])
-    expect(rspackConfig.lazyCompilation).toBe(false)
-  })
-
-  it('respects explicit lazyCompilation even when msw-storybook-addon is present', async () => {
-    const { rspackConfig } = await runRspackTool({ entries: true }, [
-      'msw-storybook-addon',
-    ])
-    expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
-  })
-
-  it('detects msw-storybook-addon when referenced via absolute path or object form', async () => {
-    const { rspackConfig } = await runRspackTool('unset', [
-      '/abs/path/to/node_modules/msw-storybook-addon',
-      { name: 'some-other-addon', options: {} },
-    ])
-    expect(rspackConfig.lazyCompilation).toBe(false)
   })
 
   it('appends raw query fallback rule for asset/source imports', async () => {

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -22,6 +22,7 @@ type LazyCompilationOption = Rspack.Configuration['lazyCompilation']
 const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
   configType: 'DEVELOPMENT' | 'PRODUCTION' = 'DEVELOPMENT',
+  addons: unknown[] = [],
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
@@ -56,6 +57,7 @@ const createOptions = (
     ['tags', {}],
     ['build', { test: {} }],
     ['previewAnnotations', []],
+    ['addons', addons],
   ])
 
   const apply = rs.fn(
@@ -139,8 +141,9 @@ describe('iframe-rsbuild.config', () => {
 
   const runRspackTool = async (
     lazyCompilation: LazyCompilationOption | 'unset',
+    addons: unknown[] = [],
   ) => {
-    const { options } = createOptions(lazyCompilation)
+    const { options } = createOptions(lazyCompilation, 'DEVELOPMENT', addons)
     const config = await createIframeRsbuildConfig(
       options as RsbuildBuilderOptions,
     )
@@ -185,6 +188,31 @@ describe('iframe-rsbuild.config', () => {
   it('passes through lazyCompilation options object', async () => {
     const { rspackConfig } = await runRspackTool({ entries: true })
     expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
+  })
+
+  // MSW's Service Worker races with the dev-server lazy-compilation RPC and
+  // leaves the preview iframe blank on cold story loads. Default-off when the
+  // addon is present; respect an explicit user override.
+  it('disables lazyCompilation when msw-storybook-addon is present and option is unset', async () => {
+    const { rspackConfig } = await runRspackTool('unset', [
+      'msw-storybook-addon',
+    ])
+    expect(rspackConfig.lazyCompilation).toBe(false)
+  })
+
+  it('respects explicit lazyCompilation even when msw-storybook-addon is present', async () => {
+    const { rspackConfig } = await runRspackTool({ entries: true }, [
+      'msw-storybook-addon',
+    ])
+    expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
+  })
+
+  it('detects msw-storybook-addon when referenced via absolute path or object form', async () => {
+    const { rspackConfig } = await runRspackTool('unset', [
+      '/abs/path/to/node_modules/msw-storybook-addon',
+      { name: 'some-other-addon', options: {} },
+    ])
+    expect(rspackConfig.lazyCompilation).toBe(false)
   })
 
   it('appends raw query fallback rule for asset/source imports', async () => {

--- a/website/docs/guide/_meta.json
+++ b/website/docs/guide/_meta.json
@@ -13,5 +13,5 @@
     "label": "Integrations"
   },
   "migration",
-  "faq"
+  "troubleshooting"
 ]

--- a/website/docs/guide/troubleshooting.mdx
+++ b/website/docs/guide/troubleshooting.mdx
@@ -109,7 +109,7 @@ export default {
 
 ## MSW integration and lazy compilation
 
-When [`msw-storybook-addon`](https://github.com/mswjs/msw-storybook-addon) is installed, the builder automatically disables lazy compilation and logs a warning at startup.
+When `mockServiceWorker.js` is found in one of the `staticDirs` entries — the convention used by [`msw-storybook-addon`](https://github.com/mswjs/msw-storybook-addon) and any hand-rolled MSW setup — the builder automatically disables lazy compilation and logs a warning at startup.
 
 This is necessary because MSW's Service Worker intercepts every `fetch` from the preview iframe, including the dev-server's lazy-compilation RPC (`POST /lazy-compilation-using-`). The SW's passthrough re-issues a fresh `fetch(clonedRequest)` that the dev-server aborts, which can leave stories stuck on a blank iframe during cold loads. The issue is rooted in how the lazy-compilation runtime talks to the dev-server via a stateful RPC channel — not a defect of the builder itself — and also affects the official `@storybook/builder-webpack5` when lazy compilation is manually enabled. A related failure mode is discussed upstream in [mswjs/msw#834](https://github.com/mswjs/msw/issues/834) (SW intercepting dev-server HMR SSE).
 

--- a/website/docs/guide/troubleshooting.mdx
+++ b/website/docs/guide/troubleshooting.mdx
@@ -1,4 +1,4 @@
-# FAQ
+# Troubleshooting
 
 ## Deploy Storybook to a subdirectory or subpath
 
@@ -106,6 +106,50 @@ export default {
   },
 }
 ```
+
+## MSW integration and lazy compilation
+
+When [`msw-storybook-addon`](https://github.com/mswjs/msw-storybook-addon) is installed, the builder automatically disables lazy compilation and logs a warning at startup.
+
+This is necessary because MSW's Service Worker intercepts every `fetch` from the preview iframe, including the dev-server's lazy-compilation RPC (`POST /lazy-compilation-using-`). The SW's passthrough re-issues a fresh `fetch(clonedRequest)` that the dev-server aborts, which can leave stories stuck on a blank iframe during cold loads. The issue is rooted in how the lazy-compilation runtime talks to the dev-server via a stateful RPC channel — not a defect of the builder itself — and also affects the official `@storybook/builder-webpack5` when lazy compilation is manually enabled. A related failure mode is discussed upstream in [mswjs/msw#834](https://github.com/mswjs/msw/issues/834) (SW intercepting dev-server HMR SSE).
+
+Leaving the auto-disable in place is the safest choice. If you never explicitly set `lazyCompilation`, no action is required on your side.
+
+If your project needs lazy compilation alongside MSW, set `lazyCompilation` explicitly in your builder options — an explicit value always takes priority over the MSW auto-disable:
+
+```ts
+// .storybook/main.ts
+export default {
+  framework: {
+    options: {
+      builder: {
+        // Opt back in — expect occasional blank iframes on cold loads.
+        lazyCompilation: { entries: false },
+      },
+    },
+  },
+}
+```
+
+When you opt back in, patch `public/mockServiceWorker.js` to let lazy-compilation RPC bypass MSW. Add this guard at the top of the `fetch` event listener, before MSW's own logic runs:
+
+```js
+// public/mockServiceWorker.js
+self.addEventListener('fetch', function (event) {
+  // Let Rspack / webpack's lazy-compilation RPC bypass MSW so the
+  // dev-server sees the original client request, not a re-issued clone.
+  if (event.request.url.includes('/lazy-compilation-using-')) {
+    return
+  }
+  // ...existing MSW handler logic
+})
+```
+
+Caveats:
+
+- `msw init` regenerates `mockServiceWorker.js` and will overwrite the patch. Re-apply it after upgrading MSW, or automate via a postinstall script that appends the guard if it is missing.
+- The bypass is scoped strictly to the lazy-compilation path; normal story requests still go through MSW and your handlers behave as before.
+- The substring match covers both the Rspack implementation (same-origin `POST /lazy-compilation-using-`) and webpack5's (dedicated random-port `GET /lazy-compilation-using-<module-path>`), so the same guard also works if you ever move to the official webpack5 builder with lazy compilation enabled.
 
 ## Why do sandboxes use `getAbsolutePath` to resolve the framework?
 


### PR DESCRIPTION
## Summary

- Detect `msw-storybook-addon` in the resolved addon list and force `lazyCompilation: false` when the user has not explicitly configured it; an explicit value always wins and a warning is logged when auto-disable kicks in.
- Rename the FAQ page to Troubleshooting and document the MSW × lazy-compilation incompatibility with a concrete `mockServiceWorker.js` bypass patch for users who must keep lazy compilation enabled.

### Why

MSW's Service Worker intercepts every `fetch` from the preview iframe, including the dev-server's lazy-compilation RPC (`POST /lazy-compilation-using-`). Its `passthrough()` re-issues a cloned fetch that the dev-server aborts, leaving cold stories stuck on a blank iframe. The issue is rooted in how the webpack-compatible lazy-compilation runtime talks to the dev-server via a stateful RPC channel and also affects `@storybook/builder-webpack5` when its lazy compilation is manually turned on; Vite is unaffected. Related upstream discussion: [mswjs/msw#834](https://github.com/mswjs/msw/issues/834).

Closes #409.

## Test plan

- [x] `pnpm exec rstest packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts` — 14/14 including 3 new MSW-detection cases
- [x] `pnpm --filter storybook-builder-rsbuild check` — no type errors
- [x] `pnpm exec biome check` on touched files — clean
- [x] `pnpm --filter website build` — dead-link checker passes