### PR TITLE
docs(website): clarify install, alias, and webpack-addon migration

### DIFF
--- a/website/docs/guide/configuration.mdx
+++ b/website/docs/guide/configuration.mdx
@@ -35,9 +35,9 @@ const config: StorybookConfig = {
       });
     }
 
-    // Example: add source alias
+    // Example: add resolve alias
     return mergeRsbuildConfig(config, {
-      source: {
+      resolve: {
         alias: {
           '@components': './src/components',
         },

--- a/website/docs/guide/framework/react-native-web.mdx
+++ b/website/docs/guide/framework/react-native-web.mdx
@@ -24,9 +24,9 @@ This framework extends `storybook-react-rsbuild` to provide full React Native We
 
 ### Installation
 
-Install the framework package and its peer dependencies:
+Install the framework package and its peer dependencies. Both `@rsbuild/core` and `@rsbuild/plugin-react` are listed directly so version pins and lockfile audits remain unambiguous.
 
-<PackageManagerTabs command="install storybook-react-native-web-rsbuild react-native-web @rsbuild/plugin-react -D" />
+<PackageManagerTabs command="install @rsbuild/core @rsbuild/plugin-react storybook-react-native-web-rsbuild react-native-web -D" />
 
 ### Configure `rsbuild.config.ts`
 

--- a/website/docs/guide/framework/react.mdx
+++ b/website/docs/guide/framework/react.mdx
@@ -22,9 +22,9 @@ Follow these steps inside an existing Rsbuild-powered React project.
 
 ### Installation
 
-Install the framework package to enable React support.
+Install the framework package and `@rsbuild/core`. Even though `storybook-react-rsbuild` declares `@rsbuild/core` as a peer, list it as a direct dev dependency so version pins and lockfile audits remain unambiguous.
 
-<PackageManagerTabs command="install storybook-react-rsbuild -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-react-rsbuild -D" />
 
 ### Configure `.storybook/main.ts`
 
@@ -34,6 +34,7 @@ import { mergeRsbuildConfig } from '@rsbuild/core'
 
 const config: StorybookConfig = {
   framework: 'storybook-react-rsbuild',
+  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   rsbuildFinal: (config) => {
     // Customize the final Rsbuild config here
     return mergeRsbuildConfig(config, {

--- a/website/docs/guide/framework/vanilla.mdx
+++ b/website/docs/guide/framework/vanilla.mdx
@@ -21,9 +21,9 @@ These steps assume you already have an Rsbuild project without a specific framew
 
 ### Installation
 
-Install the HTML framework package to enable vanilla stories.
+Install the HTML framework package and `@rsbuild/core`. Even though `storybook-html-rsbuild` declares `@rsbuild/core` as a peer, list it as a direct dev dependency so version pins and lockfile audits remain unambiguous.
 
-<PackageManagerTabs command="install storybook-html-rsbuild -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-html-rsbuild -D" />
 
 ### Configure `.storybook/main.ts`
 
@@ -33,6 +33,7 @@ import { mergeRsbuildConfig } from '@rsbuild/core'
 
 const config: StorybookConfig = {
   framework: 'storybook-html-rsbuild',
+  stories: ['../src/**/*.stories.@(js|mjs|ts)'],
   rsbuildFinal: (config) => {
     // Customize the final Rsbuild config here
     return mergeRsbuildConfig(config, {

--- a/website/docs/guide/framework/vue.mdx
+++ b/website/docs/guide/framework/vue.mdx
@@ -22,9 +22,9 @@ Use the steps below in an existing Rsbuild-based Vue project.
 
 ### Installation
 
-Install the Vue framework package to enable Storybook support.
+Install the Vue framework package and `@rsbuild/core`. Even though `storybook-vue3-rsbuild` declares `@rsbuild/core` as a peer, list it as a direct dev dependency so version pins and lockfile audits remain unambiguous.
 
-<PackageManagerTabs command="install storybook-vue3-rsbuild -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-vue3-rsbuild -D" />
 
 ### Configure `.storybook/main.ts`
 
@@ -34,6 +34,7 @@ import { mergeRsbuildConfig } from '@rsbuild/core'
 
 const config: StorybookConfig = {
   framework: 'storybook-vue3-rsbuild',
+  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   rsbuildFinal: (config) => {
     // Customize the final Rsbuild config here
     return mergeRsbuildConfig(config, {

--- a/website/docs/guide/framework/web-components.mdx
+++ b/website/docs/guide/framework/web-components.mdx
@@ -22,9 +22,9 @@ Run through these steps inside an Rsbuild project that renders Web Components.
 
 ### Installation
 
-Install the Web Components framework package.
+Install the Web Components framework package and `@rsbuild/core`. Even though `storybook-web-components-rsbuild` declares `@rsbuild/core` as a peer, list it as a direct dev dependency so version pins and lockfile audits remain unambiguous.
 
-<PackageManagerTabs command="install storybook-web-components-rsbuild -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-web-components-rsbuild -D" />
 
 ### Configure `.storybook/main.ts`
 
@@ -34,6 +34,7 @@ import { mergeRsbuildConfig } from '@rsbuild/core'
 
 const config: StorybookConfig = {
   framework: 'storybook-web-components-rsbuild',
+  stories: ['../src/**/*.stories.@(js|mjs|ts)'],
   rsbuildFinal: (config) => {
     // Customize the final Rsbuild config here
     return mergeRsbuildConfig(config, {

--- a/website/docs/guide/integrations/rslib.mdx
+++ b/website/docs/guide/integrations/rslib.mdx
@@ -12,7 +12,9 @@ See the [React component library example](https://github.com/rstackjs/storybook-
 
 ### Installation
 
-<PackageManagerTabs command="install storybook-addon-rslib -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-addon-rslib -D" />
+
+Install `@rsbuild/core` directly so the version that the addon and your framework package use is pinned in your own lockfile. Use this alongside the framework package from your project's [framework guide](/guide/framework) (e.g. `storybook-react-rsbuild`).
 
 ### Setup `.storybook/main.ts`
 

--- a/website/docs/guide/integrations/rspack.mdx
+++ b/website/docs/guide/integrations/rspack.mdx
@@ -51,22 +51,32 @@ const config: StorybookConfig = {
 export default config
 ```
 
-At this point `npx storybook dev` should launch using the default `@rsbuild/core` and `@rsbuild/plugin-react` configuration. If your stories require additional Rspack features, continue with the next step.
+At this point `npx storybook dev` should launch using the default `@rsbuild/core` and `@rsbuild/plugin-react` configuration. If your project already has its own `rspack.config`, continue with step 4 — story bundles only see what's defined in `rsbuild.config.ts`, so any custom rules, plugins, or aliases that are not mirrored here will silently be missing from your stories.
 
-### 4. Reuse custom Rspack options (optional)
+### 4. Mirror an existing `rspack.config`
 
-Projects often maintain both `rspack.config.ts` (for the application build) and `rsbuild.config.ts` (for Storybook). Import the former into the latter and merge any rules or plugins through `tools.rspack`. Refer to [tools.rspack](https://rsbuild.rs/config/tools/rspack) for every customization hook.
+If your project maintains a custom `rspack.config.ts` / `rspack.config.cjs` for the application build, mirror its essential pieces in `rsbuild.config.ts`. Storybook does not read `rspack.config` — it reads `rsbuild.config.ts`, so parity has to be explicit.
 
-The example below reuses a `less-loader` rule defined in `rspack.config.cjs`:
+When porting an existing Rspack project, walk through your `rspack.config` and mirror each of the following if it has been customized:
 
-```ts title="rsbuild.config.ts" {3,7-13}
+- **`resolve.alias`** — set on `rsbuild.config.ts` directly under [`resolve.alias`](https://rsbuild.rs/config/resolve/alias), or merge via `tools.rspack` if you prefer to keep a single source of truth.
+- **Custom `module.rules` (loaders)** — merge via [`tools.rspack`](https://rsbuild.rs/config/tools/rspack). Note that Rsbuild's built-in plugins (`pluginReact`, `pluginSass`, etc.) already register the most common loaders; only project-specific rules (e.g. `@svgr/webpack`, `less-loader` with custom options, internal codegen loaders) need to be ported.
+- **Custom `plugins`** — merge via `tools.rspack`.
+- **Custom `externals`, `output.publicPath`, `experiments`, etc.** — merge via `tools.rspack`.
+
+The example below imports an existing Rspack config and mirrors its `resolve.alias` plus a custom `less-loader` rule:
+
+```ts title="rsbuild.config.ts" {3,8-10,12-15}
 import { defineConfig } from '@rsbuild/core'
 import { pluginReact } from '@rsbuild/plugin-react'
 // import rspackConfig from './rspack.config.cjs'
-const rspackConfig = { module: { rules: [{}, {}, { loader: 'less-loader' }] } } as any
+const rspackConfig = { resolve: { alias: { '@app': './src' } }, module: { rules: [{}, {}, { loader: 'less-loader' }] } } as any
 
 export default defineConfig({
   plugins: [pluginReact()],
+  resolve: {
+    alias: rspackConfig.resolve?.alias,
+  },
   tools: {
     rspack: (config) => {
       const lessLoader = rspackConfig.module.rules[2]
@@ -76,3 +86,5 @@ export default defineConfig({
   },
 })
 ```
+
+Refer to [`tools.rspack`](https://rsbuild.rs/config/tools/rspack) for every customization hook.

--- a/website/docs/guide/migration.mdx
+++ b/website/docs/guide/migration.mdx
@@ -92,7 +92,7 @@ const config: StorybookConfig = {
   // After:
   rsbuildFinal: async (config) => {
     return mergeRsbuildConfig(config, {
-      source: {
+      resolve: {
         alias: {
           '@components': './src/components',
         },
@@ -104,6 +104,10 @@ const config: StorybookConfig = {
 
 export default config
 ```
+
+:::tip Use relative paths in `resolve.alias`
+Rsbuild resolves alias values relative to the project root. Use `'./src/components'`, not `path.resolve(__dirname, '../src/components')`. The relative form is shorter and avoids `__dirname` issues in ESM configs.
+:::
 
 ### 4. Handle webpack-dependent addons
 
@@ -132,12 +136,22 @@ export default config
 
 The `webpackAddons` field runs each addon's `webpackFinal` hook and translates the resulting webpack config into Rspack config automatically.
 
+:::tip Common addons that need `webpackAddons`
+A few addons hook `webpackFinal` internally and must move to `webpackAddons` (or be replaced with the Rsbuild-native equivalent):
+
+- `@storybook/addon-styling-webpack` — global CSS / PostCSS / Sass / Less. Either route via `webpackAddons` or replace with [`@rsbuild/plugin-postcss`](https://rsbuild.rs/plugins/list/plugin-postcss), [`@rsbuild/plugin-sass`](https://rsbuild.rs/plugins/list/plugin-sass), or [`@rsbuild/plugin-less`](https://rsbuild.rs/plugins/list/plugin-less).
+- `@storybook/addon-coverage` — collects test coverage; route via `webpackAddons`.
+- `@storybook/preset-create-react-app` — CRA compatibility; route via `webpackAddons`.
+
+If an addon's name ends in `-webpack` or its docs mention `webpackFinal`, assume it needs this treatment. Silently dropping a webpack-only addon is a regression even if `storybook build` still passes.
+:::
+
 ### 5. Convert common webpack patterns
 
 | webpack pattern                       | Rsbuild equivalent                                      |
 | ------------------------------------- | ------------------------------------------------------- |
-| `config.resolve.alias`                | `source.alias` in `rsbuildFinal`                        |
-| `config.resolve.extensions`           | `source.extensions` (Rsbuild has sensible defaults)     |
+| `config.resolve.alias`                | `resolve.alias` in `rsbuildFinal`                       |
+| `config.resolve.extensions`           | `resolve.extensions` (Rsbuild has sensible defaults)    |
 | `config.module.rules` (loaders)       | `tools.rspack` or Rsbuild plugins                       |
 | `config.plugins` (webpack plugins)    | `tools.rspack` for Rspack plugins                       |
 | `DefinePlugin`                        | `source.define`                                         |
@@ -215,7 +229,7 @@ const config: StorybookConfig = {
   // After:
   rsbuildFinal: async (config) => {
     return mergeRsbuildConfig(config, {
-      source: {
+      resolve: {
         alias: {
           '@': './src',
         },
@@ -227,11 +241,15 @@ const config: StorybookConfig = {
 export default config
 ```
 
+:::tip Use relative paths in `resolve.alias`
+Rsbuild resolves alias values relative to the project root. Use `'./src'`, not `path.resolve(__dirname, '../src')`. The relative form is shorter and avoids `__dirname` issues in ESM configs.
+:::
+
 ### 4. Convert common Vite patterns
 
 | Vite pattern                  | Rsbuild equivalent                                      |
 | ----------------------------- | ------------------------------------------------------- |
-| `resolve.alias`               | `source.alias` in `rsbuildFinal`                        |
+| `resolve.alias`               | `resolve.alias` in `rsbuildFinal`                       |
 | `plugins: [react()]`         | Auto-configured by framework package                    |
 | `css.preprocessorOptions`    | `@rsbuild/plugin-sass` or `@rsbuild/plugin-less`       |
 | `define`                      | `source.define`                                         |


### PR DESCRIPTION
## Summary

While benchmarking an LLM agent on real Storybook Rsbuild migration and fresh-setup tasks (10 fixtures × A/B with/without skill), several recurring failure modes traced back to ambiguities in the docs. This PR addresses those at the SSOT level so both human readers and AI agents get clearer guidance.

### Changes by cluster

- **`@rsbuild/core` declared directly.** All framework guides (`react`, `vue`, `vanilla`, `web-components`, `react-native-web`) and the `rslib` integration now list `@rsbuild/core` in the install command alongside the framework package. A one-line note explains that even though `@rsbuild/core` is a peer of `storybook-<framework>-rsbuild`, it should be a direct devDep so version pins and lockfile audits remain unambiguous, and a future framework-package release that drops the peer cannot silently break the build.

- **`source.alias` → `resolve.alias`.** Migration guide (both webpack5 and Vite sections) and configuration guide updated to use `resolve.alias`. Current Rsbuild emits a deprecation warning for `source.alias`. Two `:::tip` blocks recommend the relative-path form (`'./src'`) over `path.resolve(__dirname, '../src')` — the relative form is shorter and avoids `__dirname` issues in ESM configs.

- **Common webpack-only addons.** Migration step 4 now lists three concrete examples (`@storybook/addon-styling-webpack`, `@storybook/addon-coverage`, `@storybook/preset-create-react-app`) plus the rule "if the name ends in \`-webpack\`, assume it needs this treatment." This closes a gap where the previous example only used `addon-coverage`, leaving styling-related addons unrepresented.

- **Pure Rspack integration — section 4 reframe.** Heading changed from "Reuse custom Rspack options (optional)" to "Mirror an existing \`rspack.config\`". The lead-in now emphasizes that story bundles only see what's in `rsbuild.config.ts`, so anything not mirrored will silently be missing. Added a 4-item checklist (\`resolve.alias\`, custom \`module.rules\`, \`plugins\`, \`externals\`/etc) and a richer example demonstrating both alias and loader merging. A note clarifies that Rsbuild's built-in plugins (\`pluginReact\`, \`pluginSass\`, etc.) already register the most common loaders, so only project-specific rules need porting.

- **`.storybook/main.ts` examples runnable as-is.** Framework guide examples (React, Vue, vanilla, web-components) now include a `stories` glob so users can copy-paste without further edits.

## Test plan

- [ ] `pnpm dev` (in `website/`) renders all touched pages without errors
- [ ] \`\`\`ts twoslash\`\`\` code blocks still type-check
- [ ] Spot-check the rendered tip blocks in `migration.mdx` and the new section 4 example in `integrations/rspack.mdx` for formatting / line highlighting