### PR TITLE
fix(addon-modernjs): strip Storybook-owned output fields before merge

### DIFF
--- a/e2e/tests/modernjs-react.spec.ts
+++ b/e2e/tests/modernjs-react.spec.ts
@@ -1,7 +1,14 @@
+import { execFile } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
 import { expect, test } from '@playwright/test'
 import { sandboxes } from '../sandboxes'
 import { previewFrame, previewIframe } from '../utils/assertions'
 import { launchSandbox } from '../utils/sandboxProcess'
+
+const execFileAsync = promisify(execFile)
 
 const sandbox = sandboxes.find((entry) => entry.name === 'modernjs-react')
 
@@ -44,5 +51,36 @@ test.describe(sandbox.name, () => {
     const docsBody = frame.locator('body')
     await expect(docsBody).toContainText('AntdButton', { timeout: 30_000 })
     await expect(docsBody).toContainText('myButtonExtra', { timeout: 30_000 })
+  })
+})
+
+test.describe(`${sandbox.name} build output isolation`, () => {
+  // Storybook build is heavier than the dev probe; bump the per-test timeout.
+  test.setTimeout(300_000)
+
+  test('storybook build does not touch the Modern.js host dist/', async () => {
+    const sandboxDir = path.resolve(sandbox.relativeDir)
+    const hostDist = path.join(sandboxDir, 'dist')
+    const storybookStatic = path.join(sandboxDir, 'storybook-static')
+    const sentinelPath = path.join(hostDist, 'sentinel.txt')
+    const sentinelMarker = `modernjs-host-build-${Date.now()}`
+
+    // Plant a sentinel inside dist/ to simulate a prior `modern build`. The
+    // bug being guarded against has two failure modes — Storybook writing
+    // into dist/ AND Storybook wiping dist/ — so checking for the sentinel
+    // post-build catches both.
+    await rm(storybookStatic, { recursive: true, force: true })
+    await mkdir(hostDist, { recursive: true })
+    await writeFile(sentinelPath, sentinelMarker)
+
+    await execFileAsync('pnpm', ['exec', 'storybook', 'build'], {
+      cwd: sandboxDir,
+      env: { ...process.env, CI: 'true' },
+      maxBuffer: 50 * 1024 * 1024,
+    })
+
+    expect(existsSync(path.join(storybookStatic, 'iframe.html'))).toBe(true)
+    expect(existsSync(sentinelPath)).toBe(true)
+    expect(readFileSync(sentinelPath, 'utf8')).toBe(sentinelMarker)
   })
 })

--- a/e2e/tests/modernjs-react.spec.ts
+++ b/e2e/tests/modernjs-react.spec.ts
@@ -58,7 +58,7 @@ test.describe(`${sandbox.name} build output isolation`, () => {
   // Storybook build is heavier than the dev probe; bump the per-test timeout.
   test.setTimeout(300_000)
 
-  test('storybook build does not touch the Modern.js host dist/', async () => {
+  test('storybook build isolates output from Modern.js host config', async () => {
     const sandboxDir = path.resolve(sandbox.relativeDir)
     const hostDist = path.join(sandboxDir, 'dist')
     const storybookStatic = path.join(sandboxDir, 'storybook-static')
@@ -73,14 +73,29 @@ test.describe(`${sandbox.name} build output isolation`, () => {
     await mkdir(hostDist, { recursive: true })
     await writeFile(sentinelPath, sentinelMarker)
 
+    // SB_RSBUILD_TEST_LEAK_PROBE activates a guarded plugin in the sandbox's
+    // modern.config.ts that injects assetPrefix and filename overrides. If
+    // the addon stops stripping these, they'll leak through mergeRsbuildConfig
+    // and show up in the built iframe.html.
     await execFileAsync('pnpm', ['exec', 'storybook', 'build'], {
       cwd: sandboxDir,
-      env: { ...process.env, CI: 'true' },
+      env: { ...process.env, CI: 'true', SB_RSBUILD_TEST_LEAK_PROBE: '1' },
       maxBuffer: 50 * 1024 * 1024,
     })
 
+    // distPath isolation
     expect(existsSync(path.join(storybookStatic, 'iframe.html'))).toBe(true)
     expect(existsSync(sentinelPath)).toBe(true)
     expect(readFileSync(sentinelPath, 'utf8')).toBe(sentinelMarker)
+
+    // assetPrefix / filename isolation
+    const iframeHtml = readFileSync(
+      path.join(storybookStatic, 'iframe.html'),
+      'utf8',
+    )
+    expect(iframeHtml).not.toContain('leak-probe-prefix')
+    expect(iframeHtml).not.toContain('leak-probe-')
+    // Storybook's hardcoded chunk naming pattern survives.
+    expect(iframeHtml).toMatch(/iframe\.bundle\.js/)
   })
 })

--- a/e2e/tests/modernjs-react.spec.ts
+++ b/e2e/tests/modernjs-react.spec.ts
@@ -77,10 +77,15 @@ test.describe(`${sandbox.name} build output isolation`, () => {
     // modern.config.ts that injects assetPrefix and filename overrides. If
     // the addon stops stripping these, they'll leak through mergeRsbuildConfig
     // and show up in the built iframe.html.
+    //
+    // `shell: process.platform === 'win32'` mirrors the Windows-shim handling
+    // in e2e/utils/sandboxProcess.ts — Node's execFile cannot launch the
+    // `pnpm.cmd` shim directly on Windows without going through a shell.
     await execFileAsync('pnpm', ['exec', 'storybook', 'build'], {
       cwd: sandboxDir,
       env: { ...process.env, CI: 'true', SB_RSBUILD_TEST_LEAK_PROBE: '1' },
       maxBuffer: 50 * 1024 * 1024,
+      shell: process.platform === 'win32',
     })
 
     // distPath isolation

--- a/packages/addon-modernjs/src/preset.ts
+++ b/packages/addon-modernjs/src/preset.ts
@@ -124,6 +124,25 @@ export const rsbuildFinal: StorybookConfigRsbuild['rsbuildFinal'] = async (
     builderPluginAdapterHooks(adapterParams),
   ]
 
+  // Strip output fields that Storybook's preview iframe owns. builder-rsbuild
+  // hardcodes these in iframe-rsbuild.config.ts as defensive defaults, but that
+  // merge runs *before* the rsbuildFinal hook below — so any value Modern.js
+  // produced silently overrides them via mergeRsbuildConfig. Concrete leaks:
+  //   - distPath:      iframe lands in the host's `dist/`, clobbering `modern build`
+  //   - assetPrefix:   iframe.html script srcs gain the host CDN prefix (#66/#72/#224)
+  //   - cleanDistPath: Modern.js's default `true` overrides Storybook's explicit `false`
+  //   - filename:      host chunk naming overrides `[name].iframe.bundle.js`
+  if (rsbuildConfig.output) {
+    for (const key of [
+      'distPath',
+      'assetPrefix',
+      'cleanDistPath',
+      'filename',
+    ] as const) {
+      delete rsbuildConfig.output[key]
+    }
+  }
+
   // Modern.js may resolve a different version of @rsbuild/core, cast to align types.
   const finalConfig = mergeRsbuildConfig(config, rsbuildConfig as RsbuildConfig)
   return finalConfig

--- a/sandboxes/modernjs-react/modern.config.ts
+++ b/sandboxes/modernjs-react/modern.config.ts
@@ -32,6 +32,26 @@ export default defineConfig({
         })
       },
     },
+    // Leak-bait plugin: only active when SB_RSBUILD_TEST_LEAK_PROBE is set.
+    // Used by the e2e probe to verify storybook-addon-modernjs strips host
+    // output fields (assetPrefix / filename) before merging into Storybook's
+    // iframe config. See e2e/tests/modernjs-react.spec.ts.
+    {
+      name: 'modern-js-leak-probe',
+      setup(api) {
+        if (!process.env.SB_RSBUILD_TEST_LEAK_PROBE) {
+          return
+        }
+        api.config(() => ({
+          output: {
+            assetPrefix: '/leak-probe-prefix/',
+            filename: {
+              js: 'leak-probe-[name].js',
+            },
+          },
+        }))
+      },
+    },
   ],
   bff: {
     prefix: '/bff-api',


### PR DESCRIPTION
## Summary

The Modern.js addon parses the host app's `modern.config.ts` into an Rsbuild config and merges it into Storybook's config inside `rsbuildFinal`. That hook runs *after* `builder-rsbuild`'s own `iframe-rsbuild.config.ts` has already set its hardcoded defaults — so Modern.js values silently override them via `mergeRsbuildConfig`. Concrete leaks observed in the `modernjs-react` sandbox:

- `output.distPath` → Storybook iframe artifacts land in the host's `dist/`, clobbering `modern build` output.
- `output.assetPrefix` → `iframe.html` script srcs gain the host CDN prefix (related to upstream regressions #66 / #72 / #224).
- `output.cleanDistPath` → Modern.js's default `true` overrides Storybook's explicit `false`.
- `output.filename` → host chunk naming overrides `[name].iframe.bundle.js`.

Fix: delete those four Storybook-owned keys from the Modern.js-derived config before merging.

Note: `server.{port,host,htmlFallback,printUrls}` also leak from Modern.js but are reasserted in `builder-rsbuild`'s `start()`, so they don't need filtering here.

## Test plan

- [x] New e2e probe in `e2e/tests/modernjs-react.spec.ts`: plants a sentinel in `sandboxes/modernjs-react/dist/`, runs `storybook build`, asserts the sentinel survives and `storybook-static/iframe.html` is produced. Catches both write-into-dist and wipe-dist regressions.
- [x] Manually verified `assetPrefix` and `filename` filtering by temporarily setting `output.assetPrefix: '/cdn-leak-probe/'` and `output.filename.js: 'host-[name].js'` in the sandbox config: built `iframe.html` references only `*.iframe.bundle.js` with relative paths.
- [x] `pnpm check` passes for all packages.
- [x] Existing `modernjs-react` dev-server e2e test still passes.