### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,10 @@ jobs:
       heavy: ${{ steps.filter.outputs.heavy }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compute path filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # `every` so negation patterns actually exclude; default `some` OR's
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
 
@@ -101,7 +101,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
 
@@ -125,7 +125,7 @@ jobs:
         run: mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/pkg.pr.new.yaml
+++ b/.github/workflows/pkg.pr.new.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.inputs.ref }}
@@ -31,7 +31,7 @@ jobs:
           npm install -g corepack@latest --force
           corepack enable
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,12 @@ jobs:
     environment: npm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies and build
         run: pnpm install --frozen-lockfile
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: version_to_release
         with:
           result-encoding: string


### PR DESCRIPTION
## Summary

- CI is currently failing on every PR (e.g. #493) because the rstackjs org policy requires all action references to be pinned to a full-length commit SHA. Tag-form refs like `actions/checkout@v6` are rejected at the `Prepare all required actions` step, before any step runs.
- This PR pins every action reference in `.github/workflows/` to a full commit SHA, with a trailing `# vX.Y.Z` comment for readable version tracking.
- All pinned actions are bumped to their latest stable release.

### Versions

| Action | New |
|---|---|
| `actions/checkout` | `v6.0.2` |
| `actions/cache` | `v5.0.5` |
| `actions/github-script` | `v9.0.0` |
| `dorny/paths-filter` | `v4.0.1` (was `v3.0.3` / `v3`) |
| `actions/setup-node` | `v6.4.0` (already pinned; comment cleaned up) |

`dorny/paths-filter` v3 → v4 only updates the runtime to node24 and adds `merge_group` support — both compatible with current usage.

## Test plan

- [ ] CI on this PR passes: `changes`, `lint-check`, `test-build`, `ci-passed`
- [ ] Run logs show no `is not allowed in rstackjs/storybook-rsbuild because all actions must be pinned to a full-length commit SHA` errors
- [ ] Re-running CI on #493 succeeds once this lands