### PR TITLE
feat(preset): Support new htmlLang preset option

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -125,6 +125,7 @@ export default async (
     _modulesCount,
     build,
     tagsOptions,
+    htmlLang,
   ] = await Promise.all([
     presets.apply('core'),
     presets.apply('frameworkOptions'),
@@ -139,6 +140,7 @@ export default async (
     options.cache?.get('modulesCount', 1000),
     options.presets.apply('build'),
     presets.apply('tags', {}),
+    presets.apply<string>('htmlLang', 'en'),
   ])
 
   const stories = normalizeStories(nonNormalizedStories, {
@@ -481,6 +483,7 @@ export default async (
               ? { __STORYBOOK_BLOCKS_EMPTY_MODULE__: {} }
               : {}),
           },
+          htmlLang,
           headHtmlSnippet,
           bodyHtmlSnippet,
         },

--- a/packages/builder-rsbuild/templates/preview.ejs
+++ b/packages/builder-rsbuild/templates/preview.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= htmlLang %>">
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title || 'Storybook'%></title>


### PR DESCRIPTION
Closes #504. Probably.

NOTE: Can only be tested after https://github.com/storybookjs/storybook/pull/34501 is released (probably Storybook 10.5.0).