### PR TITLE
fix(builder-rsbuild): exclude node_modules from the stories require.context

### DIFF
--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -27,9 +27,18 @@ import type { BuilderOptions } from '../types'
  * `@rspack/core` — https://github.com/web-infra-dev/rspack/pull/14576.
  *
  * Adding an explicit `webpackExclude: /[\\/]node_modules[\\/]/` (honored by
- * Rspack for webpack compatibility) makes Rspack match webpack's behavior. Only
- * the guarded `webpackInclude`s are touched, so a glob that *intentionally*
- * targets `node_modules` (no guard emitted by core) is left untouched.
+ * Rspack for webpack compatibility) makes Rspack match webpack's behavior. The
+ * exclude is added to every generated `webpackInclude` except one that already
+ * targets a real `node_modules` path segment (an intentional dependency glob),
+ * which is left untouched.
+ *
+ * We gate that "leave it alone" decision on a real `[\\/]node_modules[\\/]`
+ * segment in the include rather than on core's `(?!.*node_modules)` guard: core
+ * suppresses that guard for ANY glob whose *string* merely contains the
+ * `node_modules` substring (e.g. a project globbing `@(src|node_modules-cache)`),
+ * even though such a glob is not targeting dependencies — its unanchored
+ * `webpackInclude` would still sweep real `node_modules/<pkg>/**` stories, so it
+ * must keep the exclude.
  *
  * The exclude is anchored to path separators (`[\\/]node_modules[\\/]`) rather
  * than the bare substring `node_modules`: Rspack tests `webpackExclude` against
@@ -38,20 +47,22 @@ import type { BuilderOptions } from '../types'
  * name merely contains the substring (e.g. `/builds/node_modules-cache/app/`),
  * yielding an empty stories module.
  *
- * Done with plain string scanning (not a regex) on purpose: the input is
- * generated from user-controlled story globs, and a regex spanning the comment
- * would risk polynomial backtracking (ReDoS).
+ * Scanned line by line; the only regex used is the bounded, anchorless
+ * `[\\/]node_modules[\\/]` segment test, which has no adjacent unbounded
+ * quantifiers and so runs in linear time. A regex spanning the whole
+ * user-controlled comment (with `.*` spans) is deliberately avoided to rule out
+ * polynomial backtracking (ReDoS).
  */
 export const excludeNodeModulesFromStoryContext = (importFnSource: string) =>
   importFnSource
     .split('\n')
     .flatMap((line) => {
-      // The guarded `webpackInclude` comment is the only line carrying both
-      // tokens (core emits the `(?!.*node_modules)` guard only when the glob
-      // itself doesn't target node_modules).
+      // Touch every generated `webpackInclude` except one that already targets a
+      // real `node_modules` path segment (an intentional dependency glob) — that
+      // context is meant to enumerate node_modules, so leave it alone.
       if (
         line.includes('webpackInclude:') &&
-        line.includes('(?!.*node_modules)')
+        !/[\\/]node_modules[\\/]/.test(line)
       ) {
         const indent = line.slice(0, line.length - line.trimStart().length)
         return [

--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -6,73 +6,81 @@ import {
   normalizeStories,
   readTemplate,
 } from 'storybook/internal/common'
-import type { Options, PreviewAnnotation } from 'storybook/internal/types'
+import type {
+  NormalizedStoriesSpecifier,
+  Options,
+  PreviewAnnotation,
+} from 'storybook/internal/types'
 import { toImportFn } from '../../compiled/@storybook/core-webpack'
 import type { BuilderOptions } from '../types'
 
 /**
- * Re-assert Storybook's intent to keep `node_modules` out of the stories
- * `require.context`.
- *
- * Storybook core generates a `webpackInclude` with a `(?!.*node_modules)`
- * guard, but the guard is unanchored (core strips the leading `^`) and so only
- * works because webpack's `require.context` already drops `node_modules`
- * candidates (its default `RequireContextPlugin` rewrites any path under
- * `resolve.modules` to a bare specifier and hides the relative form). Rspack's
- * `ContextModule` has no such rewrite, so it enumerates `node_modules` and the
- * guard no-ops — a dependency that ships `.stories.*` files (e.g. under its own
- * `src/`) then gets swept into the preview build and can break it.
- *
- * TODO: remove this workaround once the upstream Rspack fix ships in a released
- * `@rspack/core` — https://github.com/web-infra-dev/rspack/pull/14576.
- *
- * Adding an explicit `webpackExclude: /[\\/]node_modules[\\/]/` (honored by
- * Rspack for webpack compatibility) makes Rspack match webpack's behavior. The
- * exclude is added to every generated `webpackInclude` except one that already
- * targets a real `node_modules` path segment (an intentional dependency glob),
- * which is left untouched.
- *
- * We gate that "leave it alone" decision on a real `[\\/]node_modules[\\/]`
- * segment in the include rather than on core's `(?!.*node_modules)` guard: core
- * suppresses that guard for ANY glob whose *string* merely contains the
- * `node_modules` substring (e.g. a project globbing `@(src|node_modules-cache)`),
- * even though such a glob is not targeting dependencies — its unanchored
- * `webpackInclude` would still sweep real `node_modules/<pkg>/**` stories, so it
- * must keep the exclude.
- *
- * The exclude is anchored to path separators (`[\\/]node_modules[\\/]`) rather
- * than the bare substring `node_modules`: Rspack tests `webpackExclude` against
- * each candidate's absolute path, so a bare `/node_modules/` would also prune
- * first-party stories when the project is checked out under a directory whose
- * name merely contains the substring (e.g. `/builds/node_modules-cache/app/`),
- * yielding an empty stories module.
- *
- * Scanned line by line; the only regex used is the bounded, anchorless
- * `[\\/]node_modules[\\/]` segment test, which has no adjacent unbounded
- * quantifiers and so runs in linear time. A regex spanning the whole
- * user-controlled comment (with `.*` spans) is deliberately avoided to rule out
- * polynomial backtracking (ReDoS).
+ * Matches `node_modules` only as a complete path segment OR a complete
+ * brace/extglob alternation branch — bounded on both sides by a path separator,
+ * an alternation delimiter (`( | , {` / `) | , }`), or the string end. A fixed
+ * literal between bounded single-char classes, so it stays linear-time (no ReDoS).
  */
-export const excludeNodeModulesFromStoryContext = (importFnSource: string) =>
-  importFnSource
+const NODE_MODULES_GLOB_TOKEN = /(?:^|[\\/(|,{])node_modules(?:$|[\\/)|,}])/
+
+/**
+ * Rebuild core-webpack's `webpackIncludeGlob` (see `webpackIncludeRegexp`) from
+ * a normalized specifier, so the "intentional" check keys on the SAME structured
+ * glob core uses — not the emitted regex, where an alternation branch hides
+ * `node_modules` behind `|`/`)` instead of path separators.
+ */
+const toWebpackIncludeGlob = ({
+  directory,
+  files,
+}: NormalizedStoriesSpecifier) =>
+  ['.', '..'].includes(directory)
+    ? files
+    : `${directory.replace(/^(\.+\/)+/, '/')}/${files}`
+
+/**
+ * A specifier intentionally targets dependency stories when its glob can expand
+ * to a real `node_modules` segment — a literal path segment (`./node_modules/pkg`)
+ * or an exact alternation branch (`./@(src|node_modules)`). Substring look-alikes
+ * (`node_modules-cache`, `my-node_modules`, `modules`) do NOT count.
+ */
+const targetsNodeModules = (specifier: NormalizedStoriesSpecifier) =>
+  NODE_MODULES_GLOB_TOKEN.test(toWebpackIncludeGlob(specifier))
+
+/**
+ * Re-assert Storybook core's intent to keep `node_modules` out of the stories
+ * context. Core's `(?!.*node_modules)` guard relies on webpack's context
+ * dropping `node_modules`; Rspack's `ContextModule` enumerates it, so a
+ * dependency shipping `.stories.*` gets swept in. We append a separator-anchored
+ * `webpackExclude` to every generated `webpackInclude`, except specifiers that
+ * intentionally glob into `node_modules` (real segment or alternation branch) —
+ * matching the webpack builder, which surfaces those.
+ *
+ * TODO: remove once the upstream Rspack fix ships in a released `@rspack/core`
+ * — https://github.com/web-infra-dev/rspack/pull/14576.
+ */
+export const excludeNodeModulesFromStoryContext = (
+  importFnSource: string,
+  stories: NormalizedStoriesSpecifier[],
+) => {
+  // Core emits exactly one `webpackInclude` per specifier, in `stories` order.
+  let specifierIndex = 0
+  return importFnSource
     .split('\n')
     .flatMap((line) => {
-      // Touch every generated `webpackInclude` except one that already targets a
-      // real `node_modules` path segment (an intentional dependency glob) — that
-      // context is meant to enumerate node_modules, so leave it alone.
-      if (
-        line.includes('webpackInclude:') &&
-        !/[\\/]node_modules[\\/]/.test(line)
-      ) {
-        const indent = line.slice(0, line.length - line.trimStart().length)
-        return [
-          line,
-          `${indent}/* webpackExclude: /[\\\\/]node_modules[\\\\/]/ */`,
-        ]
+      if (!line.includes('webpackInclude:')) {
+        return [line]
       }
-      return [line]
+      const specifier = stories[specifierIndex++]
+      if (specifier && targetsNodeModules(specifier)) {
+        return [line]
+      }
+      const indent = line.slice(0, line.length - line.trimStart().length)
+      return [
+        line,
+        `${indent}/* webpackExclude: /[\\\\/]node_modules[\\\\/]/ */`,
+      ]
     })
     .join('\n')
+}
 
 export const getVirtualModules = async (options: Options) => {
   const virtualModules: Record<string, string> = {}
@@ -116,6 +124,7 @@ export const getVirtualModules = async (options: Options) => {
     toImportFn(stories, {
       needPipelinedImport,
     }),
+    stories,
   )
   // If the entrypoint is changed, remember to sync the change to Chromatic https://github.com/chromaui/chromatic-cli/pull/1206/files.
   // Also ref https://github.com/rstackjs/storybook-rsbuild/issues/332.

--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -27,12 +27,28 @@ import type { BuilderOptions } from '../types'
  * webpack compatibility) makes Rspack match webpack's behavior. Only the
  * guarded `webpackInclude`s are touched, so a glob that *intentionally* targets
  * `node_modules` (no guard emitted by core) is left untouched.
+ *
+ * Done with plain string scanning (not a regex) on purpose: the input is
+ * generated from user-controlled story globs, and a regex spanning the comment
+ * would risk polynomial backtracking (ReDoS).
  */
 export const excludeNodeModulesFromStoryContext = (importFnSource: string) =>
-  importFnSource.replace(
-    /^([ \t]*)(\/\* webpackInclude:.*\(\?!\.\*node_modules\).*\*\/)[ \t]*$/gm,
-    '$1$2\n$1/* webpackExclude: /node_modules/ */',
-  )
+  importFnSource
+    .split('\n')
+    .flatMap((line) => {
+      // The guarded `webpackInclude` comment is the only line carrying both
+      // tokens (core emits the `(?!.*node_modules)` guard only when the glob
+      // itself doesn't target node_modules).
+      if (
+        line.includes('webpackInclude:') &&
+        line.includes('(?!.*node_modules)')
+      ) {
+        const indent = line.slice(0, line.length - line.trimStart().length)
+        return [line, `${indent}/* webpackExclude: /node_modules/ */`]
+      }
+      return [line]
+    })
+    .join('\n')
 
 export const getVirtualModules = async (options: Options) => {
   const virtualModules: Record<string, string> = {}

--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -10,6 +10,30 @@ import type { Options, PreviewAnnotation } from 'storybook/internal/types'
 import { toImportFn } from '../../compiled/@storybook/core-webpack'
 import type { BuilderOptions } from '../types'
 
+/**
+ * Re-assert Storybook's intent to keep `node_modules` out of the stories
+ * `require.context`.
+ *
+ * Storybook core generates a `webpackInclude` with a `(?!.*node_modules)`
+ * guard, but the guard is unanchored (core strips the leading `^`) and so only
+ * works because webpack's `require.context` already drops `node_modules`
+ * candidates (its default `RequireContextPlugin` rewrites any path under
+ * `resolve.modules` to a bare specifier and hides the relative form). Rspack's
+ * `ContextModule` has no such rewrite, so it enumerates `node_modules` and the
+ * guard no-ops — a dependency that ships `.stories.*` files (e.g. under its own
+ * `src/`) then gets swept into the preview build and can break it.
+ *
+ * Adding an explicit `webpackExclude: /node_modules/` (honored by Rspack for
+ * webpack compatibility) makes Rspack match webpack's behavior. Only the
+ * guarded `webpackInclude`s are touched, so a glob that *intentionally* targets
+ * `node_modules` (no guard emitted by core) is left untouched.
+ */
+export const excludeNodeModulesFromStoryContext = (importFnSource: string) =>
+  importFnSource.replace(
+    /^([ \t]*)(\/\* webpackInclude:.*\(\?!\.\*node_modules\).*\*\/)[ \t]*$/gm,
+    '$1$2\n$1/* webpackExclude: /node_modules/ */',
+  )
+
 export const getVirtualModules = async (options: Options) => {
   const virtualModules: Record<string, string> = {}
   const builderOptions = await getBuilderOptions<BuilderOptions>(options)
@@ -48,9 +72,11 @@ export const getVirtualModules = async (options: Options) => {
 
   const needPipelinedImport =
     builderOptions.lazyCompilation !== false && !isProd
-  virtualModules[storiesPath] = toImportFn(stories, {
-    needPipelinedImport,
-  })
+  virtualModules[storiesPath] = excludeNodeModulesFromStoryContext(
+    toImportFn(stories, {
+      needPipelinedImport,
+    }),
+  )
   // If the entrypoint is changed, remember to sync the change to Chromatic https://github.com/chromaui/chromatic-cli/pull/1206/files.
   // Also ref https://github.com/rstackjs/storybook-rsbuild/issues/332.
   const configEntryPath = resolve(join(workingDir, 'storybook-config-entry.js'))

--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -23,10 +23,20 @@ import type { BuilderOptions } from '../types'
  * guard no-ops — a dependency that ships `.stories.*` files (e.g. under its own
  * `src/`) then gets swept into the preview build and can break it.
  *
- * Adding an explicit `webpackExclude: /node_modules/` (honored by Rspack for
- * webpack compatibility) makes Rspack match webpack's behavior. Only the
- * guarded `webpackInclude`s are touched, so a glob that *intentionally* targets
- * `node_modules` (no guard emitted by core) is left untouched.
+ * TODO: remove this workaround once the upstream Rspack fix ships in a released
+ * `@rspack/core` — https://github.com/web-infra-dev/rspack/pull/14576.
+ *
+ * Adding an explicit `webpackExclude: /[\\/]node_modules[\\/]/` (honored by
+ * Rspack for webpack compatibility) makes Rspack match webpack's behavior. Only
+ * the guarded `webpackInclude`s are touched, so a glob that *intentionally*
+ * targets `node_modules` (no guard emitted by core) is left untouched.
+ *
+ * The exclude is anchored to path separators (`[\\/]node_modules[\\/]`) rather
+ * than the bare substring `node_modules`: Rspack tests `webpackExclude` against
+ * each candidate's absolute path, so a bare `/node_modules/` would also prune
+ * first-party stories when the project is checked out under a directory whose
+ * name merely contains the substring (e.g. `/builds/node_modules-cache/app/`),
+ * yielding an empty stories module.
  *
  * Done with plain string scanning (not a regex) on purpose: the input is
  * generated from user-controlled story globs, and a regex spanning the comment
@@ -44,7 +54,10 @@ export const excludeNodeModulesFromStoryContext = (importFnSource: string) =>
         line.includes('(?!.*node_modules)')
       ) {
         const indent = line.slice(0, line.length - line.trimStart().length)
-        return [line, `${indent}/* webpackExclude: /node_modules/ */`]
+        return [
+          line,
+          `${indent}/* webpackExclude: /[\\\\/]node_modules[\\\\/]/ */`,
+        ]
       }
       return [line]
     })

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -73,6 +73,22 @@ describe('virtual-module-mapping: stories context excludes node_modules', () => 
     expect(mod).not.toMatch(/webpackExclude:\s*\/node_modules\//)
   })
 
+  // A glob whose *string* merely contains the `node_modules` substring outside a
+  // real path segment (e.g. `node_modules-cache`) is NOT intentionally targeting
+  // dependencies. Storybook core still suppresses its `(?!.*node_modules)` guard
+  // for it, so keying off that guard would skip the exclude and let the
+  // unanchored `webpackInclude` sweep real `node_modules/<pkg>/**` stories.
+  it('still excludes node_modules when a glob merely contains the substring', async () => {
+    const mod = await getStoriesModule(
+      createOptions([
+        { directory: './@(src|node_modules-cache)', files: '**/*.stories.tsx' },
+      ]),
+    )
+
+    expect(mod).toMatch(/webpackInclude:/)
+    expect(mod).toContain(pathSegmentExclude)
+  })
+
   // If a glob *intentionally* points into node_modules, Storybook core emits no
   // `(?!.*node_modules)` guard — we must not override that intent.
   it('leaves a glob that intentionally targets node_modules untouched', async () => {

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { describe, expect, it, rs } from '@rstest/core'
+import type { Options } from 'storybook/internal/types'
 import { getVirtualModules } from '../../src/preview/virtual-module-mapping'
 
 const fixtureDir = resolve(__dirname, '../fixtures')
@@ -28,10 +29,10 @@ const createOptions = (
     configType,
     presets: { apply },
     configDir: fixtureDir,
-  } as never
+  } as unknown as Options
 }
 
-const getStoriesModule = async (options: never) => {
+const getStoriesModule = async (options: Options) => {
   const { virtualModules } = await getVirtualModules(options)
   const storiesPath = resolve(process.cwd(), 'storybook-stories.js')
   return virtualModules[storiesPath]

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -38,6 +38,11 @@ const getStoriesModule = async (options: Options) => {
   return virtualModules[storiesPath]
 }
 
+// The injected exclude is anchored to path separators rather than the bare
+// `node_modules` substring, so it can't prune first-party stories when the
+// project lives under a directory whose name merely contains the substring.
+const pathSegmentExclude = '/* webpackExclude: /[\\\\/]node_modules[\\\\/]/ */'
+
 describe('virtual-module-mapping: stories context excludes node_modules', () => {
   // Rspack's require.context (unlike webpack's) enumerates node_modules, so a
   // dependency that ships `.stories.*` files would be swept into the preview
@@ -46,7 +51,7 @@ describe('virtual-module-mapping: stories context excludes node_modules', () => 
     const mod = await getStoriesModule(createOptions())
 
     expect(mod).toMatch(/webpackInclude:/)
-    expect(mod).toMatch(/webpackExclude:\s*\/node_modules\//)
+    expect(mod).toContain(pathSegmentExclude)
   })
 
   // `storybook dev` uses the pipelined/lazy import form — the exclude must
@@ -56,7 +61,16 @@ describe('virtual-module-mapping: stories context excludes node_modules', () => 
       createOptions(storiesConfig, 'DEVELOPMENT'),
     )
 
-    expect(mod).toMatch(/webpackExclude:\s*\/node_modules\//)
+    expect(mod).toContain(pathSegmentExclude)
+  })
+
+  // The exclude must be a path-segment regex, not a bare `/node_modules/`
+  // substring match — otherwise a checkout path like `/builds/node_modules-x/`
+  // would over-prune first-party stories into an empty context.
+  it('anchors the exclude to path separators, not the bare substring', async () => {
+    const mod = await getStoriesModule(createOptions())
+
+    expect(mod).not.toMatch(/webpackExclude:\s*\/node_modules\//)
   })
 
   // If a glob *intentionally* points into node_modules, Storybook core emits no
@@ -69,6 +83,6 @@ describe('virtual-module-mapping: stories context excludes node_modules', () => 
     )
 
     expect(mod).toMatch(/webpackInclude:/)
-    expect(mod).not.toMatch(/webpackExclude:\s*\/node_modules\//)
+    expect(mod).not.toContain(pathSegmentExclude)
   })
 })

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -101,4 +101,21 @@ describe('virtual-module-mapping: stories context excludes node_modules', () => 
     expect(mod).toMatch(/webpackInclude:/)
     expect(mod).not.toContain(pathSegmentExclude)
   })
+
+  // A brace/extglob alternation branch that is *exactly* `node_modules`
+  // (`./@(src|node_modules)`) also intentionally targets dependency stories —
+  // core suppresses its guard and the webpack builder surfaces them. The
+  // decision keys on the structured glob, not the emitted regex (where the
+  // branch hides `node_modules` behind `|`/`)` rather than path separators), so
+  // the exclude must be left off here too.
+  it('leaves a glob targeting node_modules as an alternation branch untouched', async () => {
+    const mod = await getStoriesModule(
+      createOptions([
+        { directory: './@(src|node_modules)', files: '**/*.stories.tsx' },
+      ]),
+    )
+
+    expect(mod).toMatch(/webpackInclude:/)
+    expect(mod).not.toContain(pathSegmentExclude)
+  })
 })

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -1,0 +1,73 @@
+import { resolve } from 'node:path'
+import { describe, expect, it, rs } from '@rstest/core'
+import { getVirtualModules } from '../../src/preview/virtual-module-mapping'
+
+const fixtureDir = resolve(__dirname, '../fixtures')
+
+// A normal stories glob (no `node_modules` in it) — Storybook core's generated
+// `webpackInclude` carries a `(?!.*node_modules)` guard for these.
+const storiesConfig = [
+  { directory: './stories', files: '*.stories.tsx', titlePrefix: '' },
+]
+
+const createOptions = (
+  stories: unknown = storiesConfig,
+  configType: 'PRODUCTION' | 'DEVELOPMENT' = 'PRODUCTION',
+) => {
+  const presetValues = new Map<string, unknown>([
+    ['core', { builder: { name: 'storybook-builder-rsbuild', options: {} } }],
+    ['stories', stories],
+    ['previewAnnotations', []],
+  ])
+
+  const apply = rs.fn(async (name: string, defaultValue?: unknown) =>
+    presetValues.has(name) ? presetValues.get(name) : defaultValue,
+  )
+
+  return {
+    configType,
+    presets: { apply },
+    configDir: fixtureDir,
+  } as never
+}
+
+const getStoriesModule = async (options: never) => {
+  const { virtualModules } = await getVirtualModules(options)
+  const storiesPath = resolve(process.cwd(), 'storybook-stories.js')
+  return virtualModules[storiesPath]
+}
+
+describe('virtual-module-mapping: stories context excludes node_modules', () => {
+  // Rspack's require.context (unlike webpack's) enumerates node_modules, so a
+  // dependency that ships `.stories.*` files would be swept into the preview
+  // build. Re-assert Storybook core's intent with an explicit webpackExclude.
+  it('adds a node_modules webpackExclude to the generated stories importFn', async () => {
+    const mod = await getStoriesModule(createOptions())
+
+    expect(mod).toMatch(/webpackInclude:/)
+    expect(mod).toMatch(/webpackExclude:\s*\/node_modules\//)
+  })
+
+  // `storybook dev` uses the pipelined/lazy import form — the exclude must
+  // apply there too (it's the more common path that hits the sweep).
+  it('also excludes node_modules in development (lazy) mode', async () => {
+    const mod = await getStoriesModule(
+      createOptions(storiesConfig, 'DEVELOPMENT'),
+    )
+
+    expect(mod).toMatch(/webpackExclude:\s*\/node_modules\//)
+  })
+
+  // If a glob *intentionally* points into node_modules, Storybook core emits no
+  // `(?!.*node_modules)` guard — we must not override that intent.
+  it('leaves a glob that intentionally targets node_modules untouched', async () => {
+    const mod = await getStoriesModule(
+      createOptions([
+        { directory: './node_modules/some-pkg', files: '*.stories.tsx' },
+      ]),
+    )
+
+    expect(mod).toMatch(/webpackInclude:/)
+    expect(mod).not.toMatch(/webpackExclude:\s*\/node_modules\//)
+  })
+})

--- a/sandboxes/react-18/.storybook/main.ts
+++ b/sandboxes/react-18/.storybook/main.ts
@@ -12,7 +12,12 @@ const getAbsolutePath = (value: string): any => {
 }
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  // Brace-rooted glob whose `modules` alternative matches `node_modules` —
+  // regression for the dependency-story sweep fixed in #506.
+  stories: [
+    '../@(modules|src)/**/*.mdx',
+    '../@(modules|src)/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
   addons: [
     '@storybook/addon-onboarding',
     '@storybook/addon-docs',


### PR DESCRIPTION
## Problem

A dependency that ships `.stories.*` files under a folder name a project's stories glob matches (e.g. its own `src/`) gets **swept into the Storybook preview build** under Rspack. With the next-rspack bridge (`storybook-next-rsbuild`) this is fatal: the swept `node_modules/*.stories.tsx` hits `next-swc-loader`'s `node_modules` exclude, no loader transforms it, and the build dies with an opaque `Module parse failed: Expected ',', got 'type'`.

Real-world repro: migrating [`transitmatters/t-performance-dash`](https://github.com/transitmatters/t-performance-dash) (glob `../@(common|modules|pages|src)/**/*.stories.tsx`) swept `@transitmatters/stripmap`'s own `src/.../LineMap.stories.tsx`.

## Root cause — a webpack ↔ rspack `ContextModule` difference

Storybook core (`@storybook/core-webpack`'s `toImportFn`) generates a `webpackInclude` with a `(?!.*node_modules)` guard, **but strips the leading `^`** (`new RegExp(src.replace(/^\^/, ''))`). Unanchored, that negative-lookahead no longer pins to position 0, so it matches a dependency's inner `…/src/x.stories.tsx` segment.

It still works under **webpack** only because webpack's default `RequireContextPlugin` taps `contextModuleFactory.hooks.alternativeRequests` and, for any context candidate under `resolve.modules` (`node_modules`), rewrites it to a **bare specifier** and **hides the relative form** — so it drops out of the `./`-anchored context (`webpack/lib/dependencies/RequireContextPlugin.js`).

**Rspack's `ContextModule` has no such rewrite**, so it enumerates `node_modules` and the guard no-ops. Verified with a standalone, Storybook-free repro (same config + same dynamic `import()` + same `webpackInclude`): webpack excludes the `node_modules` story, rspack includes it — even with a regex that matches *only* the `node_modules` file. This is a known rspack webpack-compat gap (the `ContextExclusionPlugin` / `contextModuleFiles` surface, web-infra-dev/rspack#14556), not an intentional choice.

## Fix

Inject an explicit `webpackExclude: /node_modules/` (honored by Rspack for webpack compatibility) into the generated stories `importFn`, **only** for the guarded `webpackInclude`s. A glob that *intentionally* targets `node_modules` emits no guard from core and is left untouched.

## Tests

`packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts` (behavior via `getVirtualModules`):
- adds the `node_modules` exclude to the generated stories importFn (production)
- also excludes in development (lazy/pipelined) mode
- leaves a glob that intentionally targets `node_modules` untouched

End-to-end verified: with this builder, the original brace-glob config that previously crashed now `Storybook build completed successfully` and the dependency story no longer leaks into `index.json` (8 entries, 0 stripmap).