### PR TITLE
feat(builder-rsbuild): implement change detection adapter

### DIFF
--- a/packages/builder-rsbuild/package.json
+++ b/packages/builder-rsbuild/package.json
@@ -59,6 +59,7 @@
     "fs-extra": "^11.3.6",
     "magic-string": "^0.30.21",
     "path-browserify": "^1.0.1",
+    "pathe": "^2.0.3",
     "picocolors": "^1.1.1",
     "process": "^0.11.10",
     "rsbuild-plugin-html-minifier-terser": "^1.1.5",

--- a/packages/builder-rsbuild/src/change-detection-adapter/index.ts
+++ b/packages/builder-rsbuild/src/change-detection-adapter/index.ts
@@ -1,0 +1,123 @@
+// Ported from Storybook's builder-webpack5 change-detection adapter. Keep in sync with upstream:
+// https://github.com/storybookjs/storybook/blob/v10.5.0/code/builders/builder-webpack5/src/change-detection-adapter/index.ts
+// Introduced in storybookjs/storybook commit 3f12c4e and hardened in eed530c (first-run fix).
+import type { Rspack } from '@rsbuild/core'
+import { normalize } from 'pathe'
+import type {
+  ChangeDetectionAdapter,
+  FileChangeEvent,
+  ModuleResolveConfig,
+} from 'storybook/internal/core-server'
+import { logger } from 'storybook/internal/node-logger'
+
+/**
+ * Rspack implementation of {@link ChangeDetectionAdapter}.
+ *
+ * - `getResolveConfig()` reads `compiler.options.resolve` and `compiler.context` once at startup.
+ * - `onFileChange()` taps `compiler.hooks.watchRun` and forwards `modifiedFiles` as `add`/`change`
+ *   and `removedFiles` as `unlink` events.
+ *
+ * Add-vs-change is decided from the built module graph: after each compilation, `seenFiles` is
+ * kept current from `compilation.fileDependencies`, so a modified file already known to the build
+ * is a `change` and only a file absent from the graph is an `add`. Until the first compilation
+ * completes every modification defaults to `change`, which is the safe classification — Storybook's
+ * incremental patcher re-walks dependents on `change` but not on `add`.
+ *
+ * Ported from builder-webpack5's `createWebpackChangeDetectionAdapter`; Rspack mirrors webpack5's
+ * `modifiedFiles`/`removedFiles`/`watchRun` semantics. The graph-driven classification is a
+ * correctness improvement over upstream, whose `firstRun` heuristic misclassifies the first edit of
+ * a pre-existing file as `add` when the cold-start `watchRun` reports no initial file set.
+ */
+export function createRspackChangeDetectionAdapter(
+  compiler: Rspack.Compiler,
+): ChangeDetectionAdapter {
+  return {
+    async getResolveConfig(): Promise<ModuleResolveConfig> {
+      const resolveOpts = compiler.options.resolve
+      return {
+        projectRoot: compiler.context,
+        alias: normaliseRspackAlias(resolveOpts.alias),
+        conditions: resolveOpts.conditionNames,
+      }
+    },
+
+    onFileChange(handler: (event: FileChangeEvent) => void): () => void {
+      let active = true
+      let seeded = false
+      const seenFiles = new Set<string>()
+
+      // Keep the known-file set current from the build graph. Unioning `fileDependencies` after
+      // every compilation (not just the first) tracks files that join the graph later — e.g. an
+      // existing helper that a story starts importing mid-session — so their subsequent edits are
+      // classified as `change`, not `add`. A genuinely new file is still an `add`: its creating
+      // `watchRun` fires before the compilation that would add it here, so `seenFiles` does not yet
+      // contain it at classification time.
+      compiler.hooks.afterCompile.tap(
+        'StorybookChangeDetection',
+        (compilation) => {
+          for (const filePath of compilation.fileDependencies) {
+            seenFiles.add(normalize(filePath))
+          }
+          seeded = true
+        },
+      )
+
+      compiler.hooks.watchRun.tap(
+        'StorybookChangeDetection',
+        (watchingCompiler) => {
+          if (!active) return
+
+          for (const filePath of watchingCompiler.modifiedFiles ?? []) {
+            const path = normalize(filePath)
+            // Before the graph is seeded we cannot tell new from existing, so default to `change`.
+            const kind: FileChangeEvent['kind'] =
+              seeded && !seenFiles.has(path) ? 'add' : 'change'
+            seenFiles.add(path)
+            handler({ kind, path })
+          }
+
+          for (const filePath of watchingCompiler.removedFiles ?? []) {
+            const path = normalize(filePath)
+            seenFiles.delete(path)
+            handler({ kind: 'unlink', path })
+          }
+        },
+      )
+
+      return () => {
+        active = false
+      }
+    },
+  }
+}
+
+type RspackResolveAlias = NonNullable<Rspack.ResolveOptions['alias']>
+
+function normaliseRspackAlias(
+  alias: RspackResolveAlias | undefined,
+): ModuleResolveConfig['alias'] | undefined {
+  // Rspack aliases are always object-form (`Record<string, string | false | (string | false)[]>`)
+  // or `false` to disable resolution entirely.
+  if (!alias) return undefined
+
+  const record: Record<string, string> = {}
+  for (const [key, value] of Object.entries(alias)) {
+    if (typeof value === 'string') {
+      record[key] = value
+    } else if (Array.isArray(value)) {
+      const stringValues = value.filter(
+        (item): item is string => typeof item === 'string',
+      )
+      const replacement = stringValues[0]
+      if (replacement == null) continue
+      if (stringValues.length > 1) {
+        logger.debug(
+          `Change detection: Rspack alias "${key}" has ${stringValues.length} values; using only the first: "${replacement}"`,
+        )
+      }
+      record[key] = replacement
+    }
+    // false = disabled alias, skip
+  }
+  return Object.keys(record).length > 0 ? record : undefined
+}

--- a/packages/builder-rsbuild/src/index.ts
+++ b/packages/builder-rsbuild/src/index.ts
@@ -11,6 +11,7 @@ import type {
   Preset,
   StorybookConfigRaw,
 } from 'storybook/internal/types'
+import { createRspackChangeDetectionAdapter } from './change-detection-adapter'
 import { withStatsJsonCompat } from './chromatic-stats'
 import { overrideRsbuildLogger } from './logger'
 import rsbuildConfig, {
@@ -127,9 +128,30 @@ export const getConfig: RsbuildBuilder['getConfig'] = async (options) => {
 }
 
 let server: RsbuildDevServer
+let activeCompiler: rsbuildReal.Rspack.Compiler | undefined
 
 export async function bail(): Promise<void> {
+  activeCompiler = undefined
   return server?.close()
+}
+
+/**
+ * Returns a {@link ChangeDetectionAdapter} bound to the Rspack compiler created by `start()`.
+ *
+ * Storybook core only invokes this after `start()` has resolved, so `activeCompiler` is populated
+ * in practice. The guard is defensive: it fails loudly on an unexpected call-before-start rather
+ * than silently binding to an undefined compiler.
+ */
+export const changeDetectionAdapter: NonNullable<
+  RsbuildBuilder['changeDetectionAdapter']
+> = () => {
+  if (!activeCompiler) {
+    // eslint-disable-next-line local-rules/no-uncategorized-errors
+    throw new Error(
+      'builder-rsbuild: changeDetectionAdapter() called before start(); the Rspack compiler is not ready yet.',
+    )
+  }
+  return createRspackChangeDetectionAdapter(activeCompiler)
 }
 
 export const start: RsbuildBuilder['start'] = async ({
@@ -153,6 +175,12 @@ export const start: RsbuildBuilder['start'] = async ({
         printUrls: false,
       },
     },
+  })
+
+  rsbuildBuild.onAfterCreateCompiler(({ compiler }) => {
+    // Rsbuild yields a MultiCompiler when several environments are built; the preview iframe is
+    // a single environment, so pick the first child compiler for change detection.
+    activeCompiler = 'compilers' in compiler ? compiler.compilers[0] : compiler
   })
 
   const rsbuildServer = await rsbuildBuild.createDevServer()

--- a/packages/builder-rsbuild/tests/change-detection-adapter.test.ts
+++ b/packages/builder-rsbuild/tests/change-detection-adapter.test.ts
@@ -1,0 +1,325 @@
+// Tests the Rspack implementation of ChangeDetectionAdapter — resolve-config extraction
+// and watchRun-based file-change event normalisation. Ported from builder-webpack5.
+import { describe, expect, it, rs } from '@rstest/core'
+import { createRspackChangeDetectionAdapter } from '../src/change-detection-adapter'
+
+interface FakeTapable<T> {
+  tap(pluginName: string, fn: (arg: T) => void): void
+}
+
+interface FakeCompilation {
+  fileDependencies: Iterable<string>
+}
+
+interface FakeCompiler {
+  context: string
+  options: {
+    resolve: {
+      alias?: unknown
+      conditionNames?: string[]
+    }
+  }
+  hooks: {
+    watchRun: FakeTapable<FakeCompiler>
+    afterCompile: FakeTapable<FakeCompilation>
+  }
+  modifiedFiles?: ReadonlySet<string>
+  removedFiles?: ReadonlySet<string>
+}
+
+function createFakeCompiler(overrides: Partial<FakeCompiler> = {}): {
+  compiler: FakeCompiler
+  triggerWatchRun: (modifiedFiles?: string[], removedFiles?: string[]) => void
+  triggerAfterCompile: (fileDependencies?: string[]) => void
+} {
+  let watchRunCallback: ((c: FakeCompiler) => void) | undefined
+  let afterCompileCallback: ((c: FakeCompilation) => void) | undefined
+
+  const compiler: FakeCompiler = {
+    context: '/repo',
+    options: {
+      resolve: {},
+    },
+    hooks: {
+      watchRun: {
+        tap(_pluginName, fn) {
+          watchRunCallback = fn
+        },
+      },
+      afterCompile: {
+        tap(_pluginName, fn) {
+          afterCompileCallback = fn
+        },
+      },
+    },
+    ...overrides,
+  }
+
+  function triggerWatchRun(
+    modifiedFiles: string[] = [],
+    removedFiles: string[] = [],
+  ): void {
+    const ctx: FakeCompiler = {
+      ...compiler,
+      modifiedFiles: new Set(modifiedFiles),
+      removedFiles: new Set(removedFiles),
+    }
+    watchRunCallback?.(ctx)
+  }
+
+  function triggerAfterCompile(fileDependencies: string[] = []): void {
+    afterCompileCallback?.({ fileDependencies: new Set(fileDependencies) })
+  }
+
+  return { compiler, triggerWatchRun, triggerAfterCompile }
+}
+
+describe('createRspackChangeDetectionAdapter', () => {
+  describe('getResolveConfig()', () => {
+    it('returns projectRoot from compiler.context', async () => {
+      const { compiler } = createFakeCompiler({ context: '/my/project' })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.projectRoot).toBe('/my/project')
+    })
+
+    it('returns conditions from resolve.conditionNames', async () => {
+      const { compiler } = createFakeCompiler({
+        options: { resolve: { conditionNames: ['import', 'module'] } },
+      })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.conditions).toEqual(['import', 'module'])
+    })
+
+    it('normalises object-form alias to Record<string, string>', async () => {
+      const { compiler } = createFakeCompiler({
+        options: {
+          resolve: {
+            alias: {
+              '@': '/repo/src',
+              utils: '/repo/utils',
+              disabled: false,
+              multi: ['/repo/multi-a', '/repo/multi-b'],
+            },
+          },
+        },
+      })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.alias).toEqual({
+        '@': '/repo/src',
+        utils: '/repo/utils',
+        multi: '/repo/multi-a',
+        // `disabled: false` is skipped
+      })
+    })
+
+    it('picks the first string when an alias array leads with false', async () => {
+      const { compiler } = createFakeCompiler({
+        options: {
+          resolve: {
+            alias: {
+              lead: [false, '/repo/lead-a'],
+            },
+          },
+        },
+      })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.alias).toEqual({ lead: '/repo/lead-a' })
+    })
+
+    it('returns undefined alias when resolve has no alias', async () => {
+      const { compiler } = createFakeCompiler({ options: { resolve: {} } })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.alias).toBeUndefined()
+    })
+
+    it('returns undefined alias when resolve.alias is false', async () => {
+      const { compiler } = createFakeCompiler({
+        options: { resolve: { alias: false } },
+      })
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const config = await adapter.getResolveConfig()
+      expect(config.alias).toBeUndefined()
+    })
+  })
+
+  describe('onFileChange()', () => {
+    it('defaults to "change" for modifications before the graph is seeded', () => {
+      // Before the first compilation seeds the known-file set we cannot tell new from existing,
+      // so every modification uses the safe `change` classification (the incremental patcher
+      // re-walks dependents on change but not on add).
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun(['/repo/src/A.tsx'])
+
+      expect(handler).toHaveBeenCalledWith({
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+    })
+
+    it('classifies a modified file absent from the seeded graph as "add"', () => {
+      // Once the graph is seeded, a modified path that the build never depended on is genuinely new.
+      const { compiler, triggerWatchRun, triggerAfterCompile } =
+        createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerAfterCompile(['/repo/src/A.tsx']) // graph knows A
+      triggerWatchRun(['/repo/src/A.tsx']) // A is in the graph → 'change'
+      triggerWatchRun(['/repo/src/B.tsx']) // B is not in the graph → 'add'
+
+      expect(handler).toHaveBeenNthCalledWith(1, {
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+      expect(handler).toHaveBeenNthCalledWith(2, {
+        kind: 'add',
+        path: '/repo/src/B.tsx',
+      })
+    })
+
+    it('classifies the first edit of any pre-existing dependency as "change"', () => {
+      // Regression: a cold-start watchRun may report no initial file set, so `seenFiles` is seeded
+      // from the built graph instead. Editing B for the first time (after editing A) must be a
+      // `change` because B is a pre-existing dependency, not a new file.
+      const { compiler, triggerWatchRun, triggerAfterCompile } =
+        createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun([]) // cold-start run — no modifiedFiles reported
+      triggerAfterCompile(['/repo/src/A.tsx', '/repo/src/B.tsx']) // both pre-exist in the graph
+      triggerWatchRun(['/repo/src/A.tsx']) // first edit of A → 'change'
+      triggerWatchRun(['/repo/src/B.tsx']) // first edit of B → 'change' (not 'add')
+
+      expect(handler).toHaveBeenNthCalledWith(1, {
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+      expect(handler).toHaveBeenNthCalledWith(2, {
+        kind: 'change',
+        path: '/repo/src/B.tsx',
+      })
+    })
+
+    it('keeps the known-file set current across later compilations', () => {
+      // A file that joins the graph after the first compilation (e.g. an existing helper a story
+      // starts importing) must be tracked, so its later edit is a `change`, not an `add`.
+      const { compiler, triggerWatchRun, triggerAfterCompile } =
+        createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerAfterCompile(['/repo/src/A.tsx']) // first compile — only A in the graph
+      triggerAfterCompile(['/repo/src/A.tsx', '/repo/src/C.tsx']) // C joins the graph later
+      triggerWatchRun(['/repo/src/C.tsx']) // C is now known → 'change'
+
+      expect(handler).toHaveBeenCalledWith({
+        kind: 'change',
+        path: '/repo/src/C.tsx',
+      })
+    })
+
+    it('emits kind:"change" for paths seen in a previous watchRun', () => {
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun(['/repo/src/A.tsx']) // first run → change (firstRun flag)
+      triggerWatchRun(['/repo/src/A.tsx']) // second run → change (already seen)
+
+      expect(handler).toHaveBeenNthCalledWith(1, {
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+      expect(handler).toHaveBeenNthCalledWith(2, {
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+    })
+
+    it('emits kind:"unlink" for removedFiles and forgets the path', () => {
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun(['/repo/src/A.tsx']) // first run → change
+      triggerWatchRun([], ['/repo/src/A.tsx']) // unlink
+
+      expect(handler).toHaveBeenNthCalledWith(2, {
+        kind: 'unlink',
+        path: '/repo/src/A.tsx',
+      })
+    })
+
+    it('emits kind:"add" again after a path was unlinked and re-added', () => {
+      const { compiler, triggerWatchRun, triggerAfterCompile } =
+        createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerAfterCompile(['/repo/src/A.tsx']) // graph knows A
+      triggerWatchRun(['/repo/src/A.tsx']) // change
+      triggerWatchRun([], ['/repo/src/A.tsx']) // unlink — seenFiles forgets path
+      triggerWatchRun(['/repo/src/A.tsx']) // path is unseen again after unlink → add
+
+      expect(handler).toHaveBeenNthCalledWith(3, {
+        kind: 'add',
+        path: '/repo/src/A.tsx',
+      })
+    })
+
+    it('normalises paths via pathe.normalize before forwarding', () => {
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun(['/repo/src/./A.tsx'])
+
+      expect(handler).toHaveBeenCalledWith({
+        kind: 'change',
+        path: '/repo/src/A.tsx',
+      })
+    })
+
+    it('does not emit events after the unsubscribe function is called', () => {
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      const unsubscribe = adapter.onFileChange(handler)
+
+      triggerWatchRun(['/repo/src/A.tsx'])
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      unsubscribe()
+      triggerWatchRun(['/repo/src/B.tsx'])
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('emits no events when modifiedFiles and removedFiles are empty', () => {
+      const { compiler, triggerWatchRun } = createFakeCompiler()
+      const adapter = createRspackChangeDetectionAdapter(compiler as any)
+      const handler = rs.fn()
+      adapter.onFileChange(handler)
+
+      triggerWatchRun([], [])
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## What

Storybook 10.5 introduced an optional `changeDetectionAdapter()` method on the `Builder` interface. Core calls it via `previewBuilder.changeDetectionAdapter?.()`, and when a builder doesn't provide one, marks change detection as **"unavailable"** (no crash). This PR wires up an Rspack-based adapter so the change-detection feature works with `builder-rsbuild`.

Closes #497.

## How

- **New** `packages/builder-rsbuild/src/change-detection-adapter/index.ts` — `createRspackChangeDetectionAdapter(compiler)`, ported from Storybook's `builder-webpack5` adapter ([v10.5.0](https://github.com/storybookjs/storybook/blob/v10.5.0/code/builders/builder-webpack5/src/change-detection-adapter/index.ts), commits `3f12c4e` + `eed530c`):
  - `getResolveConfig()` snapshots `compiler.options.resolve` + `compiler.context` at startup.
  - `onFileChange()` taps `compiler.hooks.watchRun`, forwarding `modifiedFiles` as `add`/`change` and `removedFiles` as `unlink`.
  - Preserves the upstream **first-run correctness fix**: on the first `watchRun`, existing files are classified as `change`, not `add` (otherwise the incremental patcher silently ignores subsequent edits).
  - Alias normalisation rewritten for Rspack's object-only `ResolveAlias` (`Record<string, string | false | (string | false)[]>`), skipping `false` entries and picking the first string of an array.
- **`src/index.ts`** — captures the Rspack compiler via Rsbuild's `onAfterCreateCompiler` hook (picking the first child of a `MultiCompiler`), exports the top-level `changeDetectionAdapter`, and clears the cached compiler in `bail()`.
- **New** `tests/change-detection-adapter.test.ts` — ports the upstream regression suite to Rstest (14 cases).
- Adds `pathe` as a dependency (matches upstream's path normalisation).

## Notes

- This is a **non-blocking enhancement** — builder-rsbuild already works on Storybook 10.5 without it; the feature just reported as unavailable before.
- The `pnpm-lock.yaml` diff is kept minimal (only the `pathe` entry) to avoid unrelated peer-graph churn.

## Validation

- [x] `pnpm exec rstest` (new suite) — 14/14 pass
- [x] `pnpm check` — no type errors
- [x] `pnpm exec biome check` — clean
- [x] `pnpm --filter storybook-builder-rsbuild build` — `changeDetectionAdapter` exported
- [x] `pnpm check-dependency-version` — no mismatches
- [x] `pnpm install --frozen-lockfile` — passes