### PR TITLE
chore: sync upstream storybook changes (#516)

### DIFF
--- a/packages/builder-rsbuild/templates/virtualModuleModernEntry.js
+++ b/packages/builder-rsbuild/templates/virtualModuleModernEntry.js
@@ -28,7 +28,6 @@ const preview = new PreviewWeb(importFn, getProjectAnnotations)
 
 window.__STORYBOOK_PREVIEW__ = preview
 window.__STORYBOOK_STORY_STORE__ = preview.storyStore
-window.__STORYBOOK_ADDONS_CHANNEL__ = channel
 
 if (import.meta.webpackHot) {
   import.meta.webpackHot.addStatusHandler((status) => {

--- a/packages/framework-react/src/react-docs.ts
+++ b/packages/framework-react/src/react-docs.ts
@@ -6,6 +6,14 @@ import type { StorybookConfig } from './types'
 export const rsbuildFinalDocs: NonNullable<
   StorybookConfig['rsbuildFinal']
 > = async (config, options): Promise<RsbuildConfig> => {
+  const features = await options.presets.apply('features', {})
+  if (features?.experimentalDocgenServer) {
+    // The docgen service owns React metadata extraction for this mode. Do not inject
+    // `Component.__docgenInfo` into the preview bundle, otherwise preview argTypes would include
+    // docgen data that the UI is now responsible for merging from the service.
+    return config
+  }
+
   const typescriptOptions = await options.presets.apply('typescript', {} as any)
   const debug = options.loglevel === 'debug'
 

--- a/sandboxes/modernjs-react-mf/host/src/stories/RemoteButton.stories.ts
+++ b/sandboxes/modernjs-react-mf/host/src/stories/RemoteButton.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/modernjs-react/src/stories/AntdButton.stories.ts
+++ b/sandboxes/modernjs-react/src/stories/AntdButton.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/react-16/src/stories/Button.stories.ts
+++ b/sandboxes/react-16/src/stories/Button.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/react-18/src/stories/AntdButton.stories.ts
+++ b/sandboxes/react-18/src/stories/AntdButton.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/react-18/src/stories/Button.stories.ts
+++ b/sandboxes/react-18/src/stories/Button.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/react-testing/src/stories/Button.stories.ts
+++ b/sandboxes/react-testing/src/stories/Button.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/rspack-react-18/src/stories/Button.stories.ts
+++ b/sandboxes/rspack-react-18/src/stories/Button.stories.ts
@@ -13,7 +13,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/sandboxes/vanilla-ts/src/stories/Header.stories.ts
+++ b/sandboxes/vanilla-ts/src/stories/Header.stories.ts
@@ -13,7 +13,7 @@ const meta = {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: 'fullscreen',
   },
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   args: {
     onLogin: fn(),
     onLogout: fn(),


### PR DESCRIPTION
Applies the actionable items from the upstream Storybook sync report (#516, range since #497).

### Changes

- **`fix(builder-rsbuild)`** — drop the redundant `window.__STORYBOOK_ADDONS_CHANNEL__ = channel` line from the modern entry template. `storybook@10.5.0`'s `addons.setChannel(channel)` now installs that global internally (`setChannel` → `syncGlobalSlot`), so the manual assignment is dead. Verified against the built preview bundle: the global is still installed at runtime via core. Mirrors upstream `a3ba897`.
- **`feat(framework-react)`** — short-circuit `rsbuildFinalDocs` when `features.experimentalDocgenServer` is enabled, so build-time `__docgenInfo` injection does not duplicate/conflict with the `core/docgen` open-service that owns React metadata in that mode. Defensive; no effect on the default path (flag is experimental, off by default). Mirrors upstream `6e4e579` (react-vite + react-webpack).
- **`docs(sandboxes)`** — fix the stale `storybook.js.org/docs/api/argtypes` doc link (now 404) to `docs/api/arg-types` across 8 sandbox story templates. Mirrors upstream `2f9421d`.

### Not ported (tracked in #516)

- `c51090f` (`needPipelinedImport` webpack-version gate) — not a mechanical sync; the webpack version semantics don't map to Rspack. Deferred until Rspack's lazy-compilation double-compilation fix status is confirmed.

### Validation

- `pnpm build` ✅
- `pnpm --filter react-18 build:storybook` (sandbox integration gate) ✅
- `framework-react` type check ✅ · Biome ✅

Closes #516
