### PR TITLE
fix(builder-rsbuild): skip mock resolution probe when no mocks are declared

### DIFF
--- a/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
@@ -4,6 +4,8 @@ import { getMockerRuntime } from 'storybook/internal/mocking-utils'
 const PLUGIN_NAME = 'RspackInjectMockerRuntimePlugin'
 
 export class RspackInjectMockerRuntimePlugin {
+  private cachedRuntime: string | null = null
+
   private getHtmlPlugin(
     compiler: Rspack.Compiler,
   ): typeof HtmlRspackPlugin | null {
@@ -39,7 +41,8 @@ export class RspackInjectMockerRuntimePlugin {
         PLUGIN_NAME,
         (data, cb) => {
           try {
-            const runtimeScriptContent = getMockerRuntime()
+            const runtimeScriptContent =
+              this.cachedRuntime ?? (this.cachedRuntime = getMockerRuntime())
             const runtimeAssetName = 'mocker-runtime-injected.js'
 
             const Sources = compiler.webpack?.sources
@@ -48,12 +51,18 @@ export class RspackInjectMockerRuntimePlugin {
                 'rspack sources is not available on compiler.webpack',
               )
             }
-            compilation.emitAsset(
-              runtimeAssetName,
-              new Sources.RawSource(runtimeScriptContent),
-            )
 
-            data.assets.js.unshift(runtimeAssetName)
+            // Emit and reference the runtime once per compilation. Re-emitting an
+            // identical asset on every rebuild triggers spurious rebuild loops in dev.
+            // See https://github.com/storybookjs/storybook/pull/33169.
+            if (!compilation.getAsset(runtimeAssetName)) {
+              compilation.emitAsset(
+                runtimeAssetName,
+                new Sources.RawSource(runtimeScriptContent),
+              )
+              data.assets.js.unshift(runtimeAssetName)
+            }
+
             cb(null, data)
           } catch (error) {
             cb(error as Error)

--- a/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
@@ -58,9 +58,9 @@ export class RspackMockPlugin {
     const updateMocks = () => {
       const mTimePreviewConfig = this.getPreviewConfigMtime(compiler)
       if (
-        this.lastPreviewMtime &&
-        mTimePreviewConfig &&
-        mTimePreviewConfig <= this.lastPreviewMtime
+        this.lastPreviewMtime !== undefined &&
+        mTimePreviewConfig !== undefined &&
+        mTimePreviewConfig === this.lastPreviewMtime
       ) {
         return // unchanged
       }

--- a/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
@@ -72,6 +72,14 @@ export class RspackMockPlugin {
           [normalizePath(mock.absolutePath.replace(/\.[^.]+$/, '')), mock],
         ]),
       )
+      // TODO: `mock.path` is not the specifier the user wrote. `extractMockCalls`
+      // strips the extension when the declared specifier's basename matches the
+      // resolved file's basename, so `sb.mock('pkg/dist/index.js')` is stored as
+      // `pkg/dist/index` while `resource.request` keeps the `.js`. The pre-filter
+      // below then misses that request and silently skips a mock it was never meant
+      // to drop. Register the extension-bearing form here as well.
+      // (builder-webpack5 has the same bug: webpack-mock-plugin.ts:86 on `next`.)
+      // See https://github.com/rstackjs/storybook-rsbuild/pull/524#discussion_r3688976092
       this.candidateSpecifiers = new Set(resolved.map((mock) => mock.path))
       this.lastPreviewMtime = mTimePreviewConfig
 

--- a/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
@@ -42,6 +42,8 @@ interface ResolvedMock extends ExtractedMock {
 export class RspackMockPlugin {
   private readonly options: RspackMockPluginOptions
   private mockMap: Map<string, ResolvedMock> = new Map()
+  private candidateSpecifiers: Set<string> = new Set()
+  private lastPreviewMtime: number | undefined
 
   constructor(options: RspackMockPluginOptions) {
     if (!options.previewConfigPath) {
@@ -54,13 +56,28 @@ export class RspackMockPlugin {
     const logger = compiler.getInfrastructureLogger(PLUGIN_NAME)
 
     const updateMocks = () => {
+      const mTimePreviewConfig = this.getPreviewConfigMtime(compiler)
+      if (
+        this.lastPreviewMtime &&
+        mTimePreviewConfig &&
+        mTimePreviewConfig <= this.lastPreviewMtime
+      ) {
+        return // unchanged
+      }
+
+      const resolved = this.extractAndResolveMocks(compiler)
       this.mockMap = new Map(
-        this.extractAndResolveMocks(compiler).flatMap((mock) => [
+        resolved.flatMap((mock) => [
           [normalizePath(mock.absolutePath), mock],
           [normalizePath(mock.absolutePath.replace(/\.[^.]+$/, '')), mock],
         ]),
       )
-      logger.info(`Mock map updated with ${this.mockMap.size / 2} mocks.`)
+      this.candidateSpecifiers = new Set(resolved.map((mock) => mock.path))
+      this.lastPreviewMtime = mTimePreviewConfig
+
+      if (resolved.length > 0) {
+        logger.info(`Mock map updated with ${resolved.length} mocks.`)
+      }
     }
 
     compiler.hooks.beforeRun.tap(PLUGIN_NAME, updateMocks)
@@ -68,10 +85,22 @@ export class RspackMockPlugin {
 
     new rspack.NormalModuleReplacementPlugin(/.*/, (resource) => {
       try {
+        // Skip the resolution probe entirely when no `sb.mock()` calls are declared —
+        // otherwise every request in the module graph pays for a `require.resolve`-style
+        // lookup for no benefit. See https://github.com/storybookjs/storybook/issues/33778.
+        if (this.mockMap.size === 0) {
+          return
+        }
+
         const path = resource.request
         const importer = resource.context
 
         const isExternal = getIsExternal(path, importer)
+        // Early filter only for external specifiers. Relative/local specifiers still need
+        // resolution to compare against the absolute paths stored in `mockMap`.
+        if (isExternal && !this.candidateSpecifiers.has(path)) {
+          return
+        }
         const absolutePath = isExternal
           ? resolveExternalModule(path, importer)
           : resolveWithExtensions(path, importer)
@@ -100,6 +129,16 @@ export class RspackMockPlugin {
         }
       }
     })
+  }
+
+  private getPreviewConfigMtime(compiler: Rspack.Compiler): number | undefined {
+    try {
+      const fs = compiler.inputFileSystem as any
+      const stat = fs.statSync?.(this.options.previewConfigPath)
+      return stat?.mtime?.getTime?.()
+    } catch {
+      return undefined
+    }
   }
 
   private extractAndResolveMocks(compiler: Rspack.Compiler): ResolvedMock[] {


### PR DESCRIPTION
## Problem

`RspackMockPlugin` registers a `NormalModuleReplacementPlugin` that matches every module request (`/.*/`) and resolves each one via `resolveWithExtensions`/`resolveExternalModule` before checking whether it's actually in the mock map — even when **zero** `sb.mock()` calls exist in `preview.ts`. This runs for the entire module graph on every build, regardless of whether module mocking is used at all.

On a large real-world codebase (hundreds of SCSS partials and SVG icons, each resolving many `@import`/`url()`/import specifiers), this took a one-shot `build-storybook` from ~1m20s to ~9m15s after upgrading through this plugin's introduction — with zero `sb.mock()` calls anywhere in the project. Profiling (Rsdoctor) showed the added time concentrated almost entirely in loaders that resolve many specifiers per file (`sass-loader`, `cssExtractLoader`, `svgo-loader`), consistent with a per-resolution tax applied uniformly across the module graph.

## This is the same bug as storybookjs/storybook#33778

The webpack5 builder's `WebpackMockPlugin` had the identical issue, reported and fixed upstream:
- Bug: storybookjs/storybook#33778 — "WebpackMockPlugin and resolveWithExtensions slow down story loading by 5-10x"
- Fix: storybookjs/storybook#33169 — adds an early exit when the mock map is empty, pre-filters external specifiers against a candidate set, and caches the mock map by the preview config's mtime instead of rebuilding it on every run.

`RspackMockPlugin` is a hand-port of the same plugin (#392) but was never updated with this fix.

## Fix

Ports the same three changes into `RspackMockPlugin`, keeping this package's existing Windows path-normalization (`normalizePath`) and `configDir` option intact:
1. Return immediately from the resolve callback when `mockMap.size === 0`.
2. Pre-filter external specifiers against a `candidateSpecifiers` set before doing a full resolve.
3. Cache the extracted mock map keyed on the preview config file's mtime, so `beforeRun`/`watchRun` don't re-parse and re-resolve on every (re)build when the file hasn't changed.

## Testing

`RspackMockPlugin.apply()` wires into rspack's native builtin `NormalModuleReplacementPlugin`, which isn't practically constructible against a mock `Compiler` in a unit test — the upstream fix for the identical webpack5 issue (#33169) also shipped without new unit tests for this reason. Verified manually instead:
- Existing `builder-rsbuild` test suite: 39/39 passing, no regressions.
- `sandboxes/react-18` (which already exercises `sb.mock()` on `greeting.ts`): built successfully, and the mocked implementation (`Mocked greeting for ...`) is correctly present in the output bundle — confirming the early-return/candidate-filter changes don't break actual mocking.
- `sandboxes/react-16` (no `sb.mock()` usage, exercising the empty-`mockMap` early-return path): builds successfully.