### PR TITLE
fix: port 6 high-severity behaviors missing from the upstream Storybook port

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -194,9 +194,9 @@ export default async (
 
   const externals: Record<string, string> = globalsNameReferenceMap
 
-  // TODO: remove in v3 (SB10)
   if (build?.test?.disableBlocks) {
-    externals['@storybook/blocks'] = '__STORYBOOK_BLOCKS_EMPTY_MODULE__'
+    externals['@storybook/addon-docs/blocks'] =
+      '__STORYBOOK_BLOCKS_EMPTY_MODULE__'
   }
 
   const { virtualModules: virtualModuleMapping, entries: dynamicEntries } =
@@ -381,6 +381,16 @@ export default async (
             ...builtInResolveExtensions,
           ]),
         )
+        // `'...'` is Rspack's sentinel for "keep the default conditions" — without it the
+        // defaults are replaced rather than extended.
+        // @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/builders/builder-webpack5/src/preview/base-webpack.config.ts#L98-L104
+        config.resolve.conditionNames = [
+          ...(config.resolve.conditionNames ?? []),
+          'storybook',
+          'stories',
+          'test',
+          '...',
+        ]
 
         config.watchOptions = {
           ignored: /node_modules/,

--- a/packages/framework-html/src/node/index.ts
+++ b/packages/framework-html/src/node/index.ts
@@ -1,5 +1,7 @@
 import type { StorybookConfig } from '../types'
 
+export type { StorybookConfig }
+
 export function defineMain(config: StorybookConfig) {
   return config
 }

--- a/packages/framework-react/src/loaders/react-docgen-loader.ts
+++ b/packages/framework-react/src/loaders/react-docgen-loader.ts
@@ -101,6 +101,28 @@ const finishInitialization = () => {
 
 let matchPath: TsconfigPaths.MatchPath | undefined
 
+/**
+ * Tsconfig filenames to try, in order.
+ *
+ * @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/presets/react-webpack/src/loaders/react-docgen-loader.ts#L86-L89
+ */
+const TSCONFIG_CANDIDATES = [
+  'tsconfig.json',
+  'tsconfig.base.json',
+  'tsconfig.app.json',
+] as const
+
+const findTsconfigPath = async (cwd: string): Promise<string | undefined> => {
+  for (const candidate of TSCONFIG_CANDIDATES) {
+    const found = await findUp(candidate, { cwd })
+    if (found) {
+      return found
+    }
+  }
+
+  return undefined
+}
+
 export default async function reactDocgenLoader(
   this: LoaderContext<{ debug: boolean }>,
   source: string,
@@ -113,7 +135,7 @@ export default async function reactDocgenLoader(
 
   if (tsconfigPathsInitializeStatus === 'uninitialized') {
     tsconfigPathsInitializeStatus = 'initializing'
-    const tsconfigPath = await findUp('tsconfig.json', { cwd: process.cwd() })
+    const tsconfigPath = await findTsconfigPath(process.cwd())
     const tsconfig = TsconfigPaths.loadConfig(tsconfigPath)
 
     if (tsconfig.resultType === 'success') {

--- a/packages/framework-react/src/react-docs.ts
+++ b/packages/framework-react/src/react-docs.ts
@@ -23,34 +23,19 @@ export const rsbuildFinalDocs: NonNullable<
     return config
   }
 
-  //#region react-docgen
-  if (reactDocgen !== 'react-docgen-typescript') {
-    return mergeRsbuildConfig(config, {
-      tools: {
-        rspack: {
-          module: {
-            rules: [
-              {
-                test: /\.(cjs|mjs|tsx?|jsx?)$/,
-                enforce: 'pre',
-                loader: requirer(
-                  require.resolve,
-                  'storybook-react-rsbuild/loaders/react-docgen-loader',
-                ),
-                options: {
-                  debug,
-                },
-                exclude: /(\.(stories|story)\.(js|jsx|ts|tsx))|(node_modules)/,
-              },
-            ],
-          },
-        },
-      },
-    })
-  }
-  //#endregion
+  const reactDocgenLoaderRule = (test: RegExp) => ({
+    test,
+    enforce: 'pre' as const,
+    loader: requirer(
+      require.resolve,
+      'storybook-react-rsbuild/loaders/react-docgen-loader',
+    ),
+    options: {
+      debug,
+    },
+    exclude: /(\.(stories|story)\.(js|jsx|ts|tsx))|(node_modules)/,
+  })
 
-  //#region react-docgen-typescript
   let typescriptPresent: boolean
   try {
     require.resolve('typescript')
@@ -59,14 +44,42 @@ export const rsbuildFinalDocs: NonNullable<
     typescriptPresent = false
   }
 
-  if (reactDocgen === 'react-docgen-typescript' && typescriptPresent) {
-  }
+  // `typescript` is an optional peerDependency here and the vendored plugin imports it
+  // dynamically, so a JS-only project must degrade rather than crash.
+  // @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/frameworks/react-vite/src/preset.ts#L26-L45
+  const useReactDocgenTypescript =
+    reactDocgen === 'react-docgen-typescript' && typescriptPresent
 
+  //#region react-docgen
+  if (!useReactDocgenTypescript) {
+    return mergeRsbuildConfig(config, {
+      tools: {
+        rspack: {
+          module: {
+            rules: [reactDocgenLoaderRule(/\.(cjs|mjs|tsx?|jsx?)$/)],
+          },
+        },
+      },
+    })
+  }
+  //#endregion
+
+  //#region react-docgen-typescript
   const reactDocGenTsPlugin = await import('./plugins/react-docgen-typescript')
 
   // TODO: Rspack doesn't support the hooks `react-docgen-typescript`' required.
   // Currently, using `transform` hook to implement the same behavior.
   return mergeRsbuildConfig(config, {
+    tools: {
+      rspack: {
+        module: {
+          // The vendored react-docgen-typescript plugin only matches `**/**.tsx`, so non-TS
+          // files still need plain react-docgen.
+          // @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/presets/react-webpack/src/framework-preset-react-docs.ts#L60
+          rules: [reactDocgenLoaderRule(/\.(cjs|mjs|jsx?)$/)],
+        },
+      },
+    },
     plugins: [
       await reactDocGenTsPlugin.default({
         ...reactDocgenTypescriptOptions,


### PR DESCRIPTION
## What

Ports six behaviors that exist in upstream Storybook but never landed in this repo. Found by a full-content drift audit against `storybookjs/storybook@next` (`3e12dfc040`) — a stateless sweep over current file contents on both sides, rather than commit-stream triage.

Notably, **two of the six were never missed upstream fixes at all** — they are branches absent since the original 2022 port. No commit-based sync process can surface those, which is what motivated the content-level audit.

## Findings

Links point at the current upstream source, pinned to the audited sha `3e12dfc040`. Provenance shas are given as plain text — three of them are bulk commits (up to 3165 files) where a link would not help.

| # | Package | Behavior | Upstream source | Provenance |
| --- | --- | --- | --- | --- |
| 1 | framework-react | `typescriptPresent` guard was inert — its `if` body was empty, so the react-docgen-typescript plugin loaded unconditionally. `typescript` is an optional peerDependency and the vendored plugin imports it dynamically, so a JS-only project setting `reactDocgen: 'react-docgen-typescript'` **failed at startup** instead of degrading. | [`react-vite/src/preset.ts#L26-L45`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/frameworks/react-vite/src/preset.ts#L26-L45) | `01e3663b76` — original design, not a fix |
| 2 | framework-react | Under the react-docgen-typescript backend, `.js/.jsx/.mjs/.cjs` files got **no docgen at all** — the vendored plugin only matches `**/**.tsx`. Upstream mounts an additional react-docgen loader on `/\.(cjs\|mjs\|jsx?)$/` in the same branch. | [`framework-preset-react-docs.ts#L60`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/presets/react-webpack/src/framework-preset-react-docs.ts#L60) | `c2bbe43d02` — original design, not a fix |
| 3 | framework-react | tsconfig lookup tried only `tsconfig.json`. Monorepos and Vite-style React apps that keep `tsconfig.base.json` / `tsconfig.app.json` at the root left `matchPath` undefined, so prop tables for aliased imports came out **silently empty**. | [`react-docgen-loader.ts#L86-L89`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/presets/react-webpack/src/loaders/react-docgen-loader.ts#L86-L89) | `07edf14e` — real bugfix, fixes upstream issue 24585 |
| 4 | builder-rsbuild | `resolve.conditionNames` was never set, so a dependency shipping a `storybook` / `stories` / `test` export condition silently resolved to its default entry and its mock/test variant never loaded. builder-vite does the same, so this is a cross-builder contract. | [`base-webpack.config.ts#L98-L104`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/builders/builder-webpack5/src/preview/base-webpack.config.ts#L98-L104) | `3ff3e13bf` — introduced with module mocking |
| 5 | builder-rsbuild | `build.test.disableBlocks` externalized `@storybook/blocks`, a package folded into `@storybook/addon-docs/blocks` in SB9. Docs blocks were bundled into `--test` builds anyway and the paired `__STORYBOOK_BLOCKS_EMPTY_MODULE__` global was dead. | [`iframe-webpack.config.ts#L107`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts#L107) | `75df3c88e` — package rename sweep |
| 6 | framework-html | `StorybookConfig` was not re-exported from `/node`, so TypeScript could not name `defineMain()`'s return type. The other three frameworks already had it — an isolated port miss. | [`html-vite/src/node/index.ts#L7`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/frameworks/html-vite/src/node/index.ts#L7) | `4ae17109` — real bugfix |

## Two deliberate deviations

1. **#1 fallback include is wider than upstream-vite.** When the guard fails, this port degrades to `/\.(cjs|mjs|tsx?|jsx?)$/`; [upstream-vite narrows to `/\.(mjs|jsx?)$/`](https://github.com/storybookjs/storybook/blob/3e12dfc040/code/frameworks/react-vite/src/preset.ts#L52), which would leave `.ts`/`.tsx` with no docgen at all. The webpack side agrees with the wider form — its `react-docgen` branch is `/\.(cjs|mjs|tsx?|jsx?)$/`.
2. **#3 ports the fallback chain only, not warnings.** Upstream's loader emits none — commit `07edf14e`'s warning strings live in `code/renderers/react/src/componentManifest/*`, a different code path. An earlier draft added them; the total-miss warning would have fired for every plain-JS project with no tsconfig, with misleading "TypeScript path aliases" text.

## Verification

`'...'` in `conditionNames` (#4) is the sentinel that re-inserts default conditions instead of replacing them. Confirmed `@rspack/core` expands it in `cleverMerge` on both the 1.x and 2.x peer ranges — without that, extending would have become replacing and broken default resolution.

All 8 PR-checklist gates pass locally on this branch's base:

| Gate | Result |
| --- | --- |
| `pnpm check` | 10/10 packages, no type errors |
| `pnpm lint` | 482 files, 0 fixes |
| `pnpm check-dependency-version` | no mismatches |
| `pnpm build` | pass |
| `pnpm build:sandboxes` | pass |
| `pnpm test` | 95/95 |
| `pnpm build:test` | pass |
| `pnpm e2e` | 22 passed, 1 skipped |

**One gap worth flagging:** no sandbox sets `build.test.disableBlocks`, so #5's runtime path is verified by source parity with upstream and by confirming the paired global is emitted under the same condition — **not by execution**. A sandbox exercising `disableBlocks` would close this.

## Out of scope

The same audit surfaced 20 further findings (12 medium, 8 low) plus 12 undocumented divergences, all deferred. Two are worth pulling forward soon:

- **`getProjectRoot()` bound on tsconfig find-up** (framework-react) — this PR *amplifies* the existing unbounded lookup from one filename to three, so an unrelated ancestor's `tsconfig.base.json` can now also be picked up. Same function #3 touches.
- **`webpackFinal` / `webpackAddons` gating** (builder-rsbuild) — third-party addons implementing only `webpackFinal` are silently inert unless explicitly listed.
